### PR TITLE
Upgrade lit-html.

### DIFF
--- a/mixins/lit-html-mixin.js
+++ b/mixins/lit-html-mixin.js
@@ -2,22 +2,22 @@ import { render, html } from '../../../lit-html/lit-html.js';
 
 import { asyncAppend } from '../../../lit-html/directives/async-append.js';
 import { asyncReplace } from '../../../lit-html/directives/async-replace.js';
+import { cache } from '../../../lit-html/directives/cache.js';
 import { guard } from '../../../lit-html/directives/guard.js';
 import { ifDefined } from '../../../lit-html/directives/if-defined.js';
 import { repeat } from '../../../lit-html/directives/repeat.js';
 import { unsafeHTML } from '../../../lit-html/directives/unsafe-html.js';
 import { until } from '../../../lit-html/directives/until.js';
-import { when } from '../../../lit-html/directives/when.js';
 
 const directives = {
   asyncAppend,
   asyncReplace,
+  cache,
   guard,
   ifDefined,
   repeat,
   unsafeHTML,
   until,
-  when,
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "/index.css"
   ],
   "dependencies": {
-    "lit-html": "^0.13.0"
+    "lit-html": "^1.0.0-rc.2"
   },
   "devDependencies": {
     "@netflix/element-server": "^1.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,10 +627,10 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lit-html@^0.13.0:
-  version "0.13.0"
-  resolved "https://artifacts.netflix.com/api/npm/npm-netflix/lit-html/-/lit-html-0.13.0.tgz#d05e7fe8ade572432120339c451c614669788adf"
-  integrity sha1-0F5/6K3lckMhIDOcRRxhRml4it8=
+lit-html@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://artifacts.netflix.com/api/npm/npm-netflix/lit-html/-/lit-html-1.0.0-rc.2.tgz#b9c904520fe005d349aa737a86d83645d97d5a89"
+  integrity sha1-uckEUg/gBdNJqnN6htg2Rdl9Wok=
 
 lodash@^4.17.10, lodash@^4.17.5:
   version "4.17.10"


### PR DESCRIPTION
The `when` directive was removed.
The `cache` directive was added.

Not that you can use a ternary in a `cache` wrapper to reproduce `when` functionality.