### PR TITLE
Refactor x-element mixins.

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,120 @@
+# The `x-element` spec
+
+This describes the expected behavior of `x-element`.
+
+## Mixin hierarchy
+
+The `x-element` code is organized in a set of progressively-enhancing mixins
+which are intended to be used in order. You can only omit mixins from the tail,
+not from the middle/head. The intent is to force the correct base hooks so that
+custom extension is supported.
+
+### `element-mixin`
+
+Provides base functionality for creating custom elements with shadow roots and
+hooks to re-render the element.
+
+### `properties-mixin`
+
+Allows you to declare the `properties` block. This leverages the `element-mixin`
+to observe and `invalidate` on property changes to cause a re-render. The
+`properties` block allows you to declare the following via this mixin:
+
+- `type` [Function]: type associated with the property.
+- `value` [Funciton|Any Literal]: _initial_ value for the property or getter.
+- `readOnly` [Boolean]: prevent property updates via normal setter?
+
+### `property-effects-mixin`
+
+Enhances the interface to properties block to handle _property effects_. I.e.,
+effects that can take place whenever a property updates. This adds the following
+configuration to the properties block:
+
+- `reflect` [Boolean]: reflect property to attribute?
+- `observer` [String]: DSL used to resolve an observer callback
+- `computed` [String]: DSL used to resolve computed callback and dependencies
+
+### `lit-html-mixin`
+
+This mixin simply makes an opinion to use `lit-html` as the templating engine.
+
+## Lifecycle
+
+### Analysis
+
+Analysis should take place once per class on first construction. This allows all
+future instances to share common setup work. The result of the analysis phase is
+made available again during initialization.
+
+Note: work to truly cache analysis work per-class is ongoing. Right now, this
+happens per instance.
+
+### Initialization
+
+Initialization should take place once per instance on first connection. This
+allows each class to leverage cached information in the analysis phase and
+leverage initialization work through disconnection and reconnection to the DOM.
+Initialization should work in the following order:
+
+- handle post-definition upgrade scenario
+- initialize render root
+- initialize property values
+- compute properties
+- render
+- enable property effects
+- reflect properties
+- observe properties
+
+### Update
+
+When properties update on an initialized element, the following should occur:
+
+- reflect property if needed
+- observe property if needed
+- compute dependent properties if needed, causes subsequent property changes
+
+## Properties
+
+The properties block allows you to define the following:
+
+- `type` [Function]: type associated with the property
+- `value` [Funciton|Any Literal]: _initial_ value for the property or getter
+- `readOnly` [Boolean]: prevent property updates via normal setter?
+- `reflect` [Boolean]: reflect property to attribute?
+- `observer` [String]: DSL used to resolve an observer callback
+- `computed` [String]: DSL used to resolve computed callback and dependencies
+
+## References
+
+- [WHATWG Custom Elements Spec](https://html.spec.whatwg.org/multipage/custom-elements.html)
+
+
+## Computed properties and graphs
+
+Consider the following properties:
+
+```
+{
+  a: { type: Boolean },
+  b: { type: Boolean, computed: 'computeB(a)' },
+  c: { type: Boolean, computed: 'computeC(a, b)' }
+}
+```
+
+This properties block declares that `c` depends on `a` and `b` and that `b`
+depends on `a`. However, the _order_ in which we resolve `b` and `c` when `a`
+changes is important. In general, computed properties form a Directed, Acyclic
+Graph (DAG). The DAG looks like this:
+
+```
+      a
+   ↙     ↘
+b     →     c
+```
+
+DAGs can be solved using a topological sorting algorithm and this computation
+can be done at analysis-time to prevent repeating expensive work at runtime.
+
+Note that DAGs can have multiple solutions. For completeness, the solution for
+this DAG is `[a, b, c]`. This means that if `a` changes, you need to then update
+`b` and then update `c`--in that order.

--- a/etc/graph.js
+++ b/etc/graph.js
@@ -1,0 +1,80 @@
+export default class Graph {
+  constructor(nodes, edges) {
+    // Defend against mutations during sorting by freezing nodes and edges.
+    Reflect.defineProperty(this, 'nodes', { value: Object.freeze([...nodes]) });
+    Reflect.defineProperty(this, 'edges', { value: Object.freeze([...edges]) });
+    for (const edge of this.edges) {
+      Object.freeze(edge);
+    }
+  }
+
+  static _makeGraphLoop(n, mapping, edges, nodes) {
+    if (nodes.includes(n) === false) {
+      // Don't traverse nodes we've already traversed. Prevents infinite loop.
+      nodes.push(n);
+      if (n in mapping) {
+        for (const m of mapping[n]) {
+          edges.push([n, m]);
+          this._makeGraphLoop(m, mapping, edges, nodes);
+        }
+      }
+    }
+  }
+
+  static createFromNodeMapping(node, mapping) {
+    const edges = [];
+    const nodes = [];
+    this._makeGraphLoop(node, mapping, edges, nodes);
+    return new Graph(nodes, edges);
+  }
+
+  static sort(graph) {
+    // Implements Kahn's algorithm for topological sorting:
+    //
+    //   solution ← empty list that will contain the sorted elements
+    //   nodes ← set of all nodes with no incoming edge
+    //   while nodes is non-empty do
+    //     remove a node currentNode from nodes
+    //     add currentNode to tail of solution
+    //     for each node testNode with an edge testEdge from currentNode to testNode do
+    //       remove edge testEdge from edges
+    //       if testNode has no other incoming edges then
+    //         insert testNode into nodes
+    //   if edges then
+    //     return undefined (graph has at least one cycle)
+    //   else
+    //     return solution (a topologically sorted list)
+    //
+    // Assumptions:
+    //
+    //   1. Each node in each edge in "graph.edges" is in "graph.nodes".
+    //   2. Each node in "graph.nodes" is unique in the list.
+    //   3. Each edge in "graph.edges" is unique in the list.
+    if (graph instanceof Graph === false) {
+      throw new Error('Cannot call topologicalSort on non-Graph instance.');
+    }
+    const edges = [...graph.edges];
+    const solution = [];
+    const hasNoIncomingEdges = node => edges.every(edge => edge[1] !== node);
+    const nodes = new Set(graph.nodes.filter(hasNoIncomingEdges));
+    while (nodes.size) {
+      const currentNode = nodes.values().next().value;
+      nodes.delete(currentNode);
+      solution.push(currentNode);
+      // Loop over a copy of "edges" to prevent mutation while looping.
+      for (const testEdge of [...edges]) {
+        if (testEdge[0] === currentNode) {
+          const testNode = testEdge[1];
+          edges.splice(edges.indexOf(testEdge), 1);
+          if (hasNoIncomingEdges(testNode)) {
+            nodes.add(testNode);
+          }
+        }
+      }
+    }
+    // If there are remaining edges, the graph is cyclic; return undefined.
+    if (edges.length === 0) {
+      return solution;
+    }
+  }
+}

--- a/mixins/properties-mixin.js
+++ b/mixins/properties-mixin.js
@@ -1,44 +1,20 @@
+/**
+ * Provides declarative 'properties' block.
+ */
+
 const DASH_TO_CAMEL = /-[a-z]/g;
 const CAMEL_TO_DASH = /([A-Z])/g;
-const COMPUTED_REGEX = /^(.+)\((.+)\)$/;
+const PROPERTY_DEFINITIONS = Symbol.for('__propertyDefinitions__');
+const PROPERTIES_INITIALIZED = Symbol.for('__propertiesInitialized__');
+const PROPERTY_VALUE_CACHE = Symbol.for('__propertyValueCache__');
 
 const caseMap = new Map();
 
 /**
  * Provides property management via a declarative 'properties' block.
  */
-// TODO: come closer to parity with LitElement.
 export default superclass =>
   class extends superclass {
-    connectedCallback() {
-      super.connectedCallback();
-      // Only reflect attributes when the element is connected
-      // See https://dom.spec.whatwg.org/#dom-node-isconnected
-      this.constructor.initializeProperties(this);
-    }
-
-    attributeChangedCallback(attr, oldValue, newValue, namespace) {
-      super.attributeChangedCallback(attr, oldValue, newValue, namespace);
-      if (newValue !== oldValue && this.propertiesInitialized) {
-        // Ensure all attribute changes are processed by property accessors.
-        // Required for frameworks which set attributes instead of props.
-        // Keeping properties in sync with attributes is less confusing too.
-        // NOTE: initial attribute values are processed in `connectedCallback`
-        const props = this.constructor.properties;
-        const prop = this.constructor.dashToCamelCase(attr);
-        const type = props[prop].type;
-        this[prop] = this.constructor.deserializeAttribute(
-          attr,
-          newValue,
-          type
-        );
-      }
-    }
-
-    get propertiesInitialized() {
-      return this[Symbol.for('__propertiesInitialized__')];
-    }
-
     static get properties() {
       return {};
     }
@@ -54,251 +30,143 @@ export default superclass =>
       }
     }
 
-    static initializeProperties(target) {
-      if (!target.propertiesInitialized) {
-        const definitions = this.properties;
-        const properties = Reflect.ownKeys(definitions);
-
-        // Initialize objects to be passed around to resolve computed properties
-        // and observe values. These are mutated during initialization, but
-        // remain constant after.
-        const dependents = new Map();
-        const dependencies = new Map();
-        const resolvers = new Map();
-        const observers = new Map();
-
-        // Define all declared properties on target instance.
-        for (const property of properties) {
-          const definition = definitions[property];
-          this.addPropertyAccessor(
-            target,
-            dependencies,
-            dependents,
-            resolvers,
-            observers,
-            property,
-            definition
-          );
-        }
-
-        // Validate and resolve computed properties.
-        const computedProperties = properties.filter(
-          property => !!definitions[property].computed
-        );
-        for (const property of computedProperties) {
-          // Check for a cyclic dependency here to prevent max recursion errors.
-          if (this.propertyHasCyclicDependencies(property, dependencies)) {
-            throw new Error(`Property "${property}" has a cyclic dependency.`);
-          }
-          // Only allow access to defined properties.
-          const strings = dependencies.get(property);
-          for (const string of strings) {
-            if (!properties.includes(string)) {
-              throw new Error(`"${property}" depends on unknown "${string}".`);
-            }
-          }
-        }
-        const invalidProperties = new Set(computedProperties);
-        this.resolveInvalidProperties(
-          dependencies,
-          resolvers,
-          invalidProperties
-        );
-
-        target[Symbol.for('__propertiesInitialized__')] = true;
-
-        // Call all observers after initialization. They may cause side effects.
-        const observedProperties = properties.filter(
-          property => definitions[property].observer
-        );
-        for (const property of observedProperties) {
-          // Don't call observer if no initialization has happened.
-          if (target[property] !== undefined) {
-            observers.get(property)(undefined, target[property]);
-          }
-        }
-      }
+    get propertyDefinitions() {
+      // This is defined during analysis and should only be used thereafter.
+      return this[PROPERTY_DEFINITIONS];
     }
 
-    static addPropertyAccessor(
-      target,
-      dependencies,
-      dependents,
-      resolvers,
-      observers,
-      property,
-      definition
-    ) {
-      const { computed, observer, type, reflect } = definition;
+    static analyzeProperty(target, property, definition) {
+      return definition;
+    }
+
+    static analyzeProperties(target, properties) {
+      const propertyDefinitions = {};
+      for (const [property, definition] of Object.entries(properties)) {
+        propertyDefinitions[property] = this.analyzeProperty(
+          target,
+          property,
+          definition
+        );
+      }
+      target[PROPERTY_DEFINITIONS] = propertyDefinitions;
+      target[PROPERTY_VALUE_CACHE] = {};
+    }
+
+    static getInitialValue(target, property, definition) {
+      // Process possible sources of initial state, with this priority:
+      // 1. imperative, e.g. `element.prop = 'value';`
+      // 2. declarative, e.g. `<element prop="value"></element>`
+      // 3. definition, e.g. `properties: { prop: { value: 'value' } }`
+      if (definition.readOnly) {
+        return;
+      }
       const attribute = this.camelToDashCase(property);
-      const symbol = Symbol.for(property);
-
-      // If computed, generate dependents, dependencies & resolvers.
-      if (computed) {
-        // Parse computed DSL. E.g., "myFunc(propOne, propTwo)".
-        const declarationMatch = computed.match(COMPUTED_REGEX);
-        if (!declarationMatch) {
-          throw new Error(`Malformed computed "${computed}".`);
-        }
-        const [methodName, dependenciesString = ''] = declarationMatch.slice(1);
-        const strings = dependenciesString.split(',').map(dep => dep.trim());
-        dependencies.set(property, strings);
-
-        // Provide a resolver callback after computed property is invalidated.
-        resolvers.set(property, () => {
-          // Collect property values for all arguments from dependencies.
-          const args = dependencies
-            .get(property)
-            .map(dependency => target[dependency]);
-          // Method may be static or instance.
-          const { method, thisArg } = this.resolveMethodName(
-            target,
-            methodName
-          );
-          const newValue = method.call(thisArg, ...args);
-          // Ensure method's return is properly typed as per the user definition.
-          const newTypedValue = this.applyType(newValue, type);
-          // Store the old value in case we have an observer.
-          const oldTypedValue = target[symbol];
-          // Only make propagating changes if the property actually changed.
-          if (newTypedValue !== oldTypedValue) {
-            // Computed properties do not have a setter, set value directly.
-            target[symbol] = newTypedValue;
-            // Call observers immediately. Dependents aren't computed yet.
-            if (target.propertiesInitialized && observers.has(property)) {
-              observers.get(property)(oldTypedValue, newTypedValue);
-            }
-            if (reflect) {
-              this.reflectProperty(target, attribute, type, newTypedValue);
-            }
-            // Mark template dirty. We have an edge case during initialization
-            // where properties can be computed even though no dependencies have
-            // been invalidated. This ensures a re-render in that case.
-            target.invalidate();
-          }
-        });
-
-        // Include property as a dependant of all it's dependencies.
-        for (const dependency of dependencies.get(property)) {
-          if (!dependents.has(dependency)) {
-            dependents.set(dependency, new Set());
-          }
-          dependents.get(dependency).add(property);
-        }
-      }
-
-      // If observed, create a callback for setters.
-      if (observer) {
-        const methodName = observer;
-        observers.set(property, (oldValue, newValue) => {
-          // Method may be static or instance.
-          const { method, thisArg } = this.resolveMethodName(
-            target,
-            methodName
-          );
-          method.call(thisArg, oldValue, newValue);
-        });
-      }
-
-      // Define getter and setter for property.
-      const descriptor = {
-        get() {
-          return target[symbol];
-        },
-      };
-      if (computed) {
-        descriptor.set = () => {
-          // Treat computed setter as a noop. No need to invalidate. This is how
-          // we ensure reflected, computed properties only change internally.
-          if (reflect) {
-            this.reflectProperty(target, attribute, type, target[property]);
-          }
-        };
-      } else {
-        descriptor.set = newValue => {
-          // Apply the user-provided type function and set with the result.
-          const newTypedValue = this.applyType(newValue, type);
-          // Store the old value in case we have an observer.
-          const oldTypedValue = target[symbol];
-          // Only make propagating changes if the property actually changed.
-          if (newTypedValue !== oldTypedValue) {
-            target[symbol] = newTypedValue;
-            // Call observers immediately. Dependents aren't computed yet.
-            if (target.propertiesInitialized && observers.has(property)) {
-              observers.get(property)(oldTypedValue, newTypedValue);
-            }
-            if (reflect) {
-              this.reflectProperty(target, attribute, type, newTypedValue);
-            }
-            // Post-initialization, ensure dependent properties are resolved.
-            if (target.propertiesInitialized && dependents.has(property)) {
-              const invalidProperties = this.invalidateProperty(
-                dependents,
-                property
-              );
-              this.resolveInvalidProperties(
-                dependencies,
-                resolvers,
-                invalidProperties
-              );
-            }
-            // Mark template dirty.
-            target.invalidate();
-          }
-        };
-      }
-
-      // Store initial property value and then redefine with our descriptor.
       const initialPropertyValue = target[property];
-      Reflect.deleteProperty(target, property);
-      Reflect.defineProperty(target, property, descriptor);
-
-      // If the property isn't computed, initialize it.
-      if (!computed) {
-        // Process possible sources of initial state, with this priority:
-        // 1. imperative, e.g. `element.prop = 'value';`
-        // 2. declarative, e.g. `<element prop="value"></element>`
-        // 3. definition, e.g. `properties: { prop: { value: 'value' } }`
-        const { value: defaultValue } = definition;
-        if (initialPropertyValue !== undefined) {
-          target[property] = initialPropertyValue;
-        } else if (target.hasAttribute(attribute)) {
-          const attributeValue = target.getAttribute(attribute);
-          target[property] = this.deserializeAttribute(
-            attribute,
-            attributeValue,
-            type
-          );
-        } else if (defaultValue !== undefined) {
-          target[property] =
-            defaultValue instanceof Function ? defaultValue() : defaultValue;
-        }
+      if (initialPropertyValue !== undefined) {
+        return initialPropertyValue;
+      } else if (target.hasAttribute(attribute)) {
+        const value = target.getAttribute(attribute);
+        return this.deserializeAttribute(target, property, definition, value);
+      } else if (definition.value !== undefined) {
+        const defaultValue = definition.value;
+        return defaultValue instanceof Function ? defaultValue() : defaultValue;
       }
     }
 
-    static reflectProperty(target, attr, type, value) {
-      if (type.name === 'Boolean') {
-        if (value) {
-          // Any non-null attribute is a valid boolean. No need to change.
-          if (Object.is(target.getAttribute(attr), null)) {
-            target.setAttribute(attr, '');
-          }
-        } else {
-          target.removeAttribute(attr);
+    static initializeProperty(target, property, definition) {
+      const symbol = Symbol.for(property);
+      const get = () => target[symbol];
+      const set = rawValue => {
+        const oldRawValue = target[PROPERTY_VALUE_CACHE][property];
+        const propertyShouldChange = this.shouldPropertyChange(
+          target,
+          property,
+          definition,
+          rawValue,
+          oldRawValue
+        );
+        if (propertyShouldChange) {
+          target[PROPERTY_VALUE_CACHE][property] = rawValue;
+          const value = this.applyType(rawValue, definition.type);
+          this.changeProperty(target, property, definition, value);
         }
-      } else if (type.name === 'String' || type.name === 'Number') {
-        // avoid reflecting non-values
-        if (value === undefined || Object.is(value, null)) {
-          target.removeAttribute(attr);
-        } else {
-          target.setAttribute(attr, value);
-        }
-      } else {
-        const message =
-          `Attempted to write "${attr}" as a reflected attribute, ` +
-          `but it is not a Boolean, String, or Number type (${type.name}).`;
-        target.dispatchError(new Error(message));
+      };
+      const configurable = false;
+      Reflect.deleteProperty(target, property);
+      Reflect.defineProperty(target, property, { get, set, configurable });
+    }
+
+    static beforeInitialRender(target) {
+      super.beforeInitialRender(target);
+
+      // Analysis may dispatchErrors, only do this after element is connected.
+      this.analyzeProperties(target, this.properties);
+
+      // Only reflect attributes when the element is connected
+      // See https://dom.spec.whatwg.org/#dom-node-isconnected
+      const entries = Object.entries(target.propertyDefinitions);
+      for (const [property, definition] of entries) {
+        const value = this.getInitialValue(target, property, definition);
+        this.initializeProperty(target, property, definition);
+        target[property] = value;
       }
+
+      // Allows us to guard against early handling in attributeChangedCallback.
+      target[PROPERTIES_INITIALIZED] = true;
+    }
+
+    static shouldPropertyChange(
+      target,
+      property,
+      definition,
+      rawValue,
+      oldRawValue
+    ) {
+      return (
+        !definition.readOnly &&
+        rawValue !== oldRawValue &&
+        (rawValue === rawValue || oldRawValue === oldRawValue)
+      );
+    }
+
+    static propertyWillChange(target, property, definition, value, oldValue) {
+      // Provided for symmetry with propertyDidChange.
+    }
+
+    static propertyDidChange(target, property, definition, value, oldValue) {
+      target.invalidate();
+    }
+
+    static changeProperty(target, property, definition, value) {
+      // For internal use. Needed to set readOnly properties.
+      const symbol = Symbol.for(property);
+      this.propertyWillChange(target, property, definition, value);
+      const oldValue = target[property];
+      target[symbol] = value;
+      this.propertyDidChange(target, property, definition, value, oldValue);
+    }
+
+    attributeChangedCallback(attribute, oldValue, newValue, namespace) {
+      super.attributeChangedCallback(attribute, oldValue, newValue, namespace);
+      if (newValue !== oldValue && this[PROPERTIES_INITIALIZED]) {
+        const ctor = this.constructor;
+        const property = ctor.dashToCamelCase(attribute);
+        const definition = this.propertyDefinitions[property];
+        this[property] = ctor.deserializeAttribute(
+          this,
+          property,
+          definition,
+          newValue
+        );
+      }
+    }
+
+    static deserializeAttribute(target, property, definition, value) {
+      if (definition.type.name === 'Boolean') {
+        // per HTML spec, every value other than null is considered true
+        return Object.is(value, null) === false;
+      }
+      return value;
     }
 
     static applyType(value, type) {
@@ -322,91 +190,6 @@ export default superclass =>
       }
       // otherwise coerce type as needed
       return value instanceof type ? value : type(value);
-    }
-
-    static deserializeAttribute(attr, value, type) {
-      // per the HTML spec, every value other than null
-      // is considered true for boolean attributes
-      if (type.name === 'Boolean') {
-        return Object.is(value, null) === false;
-      }
-      return value;
-    }
-
-    static propertyHasCyclicDependencies(property, dependencies, seen = []) {
-      if (dependencies.has(property)) {
-        for (const dependency of dependencies.get(property)) {
-          if (
-            dependency === property ||
-            seen.includes(dependency) ||
-            this.propertyHasCyclicDependencies(dependency, dependencies, [
-              ...seen,
-              property,
-            ])
-          ) {
-            return true;
-          }
-        }
-      }
-      return false;
-    }
-
-    static invalidateProperty(dependents, property) {
-      // Recursively generate the invalidity tree.
-      const invalidProperties = new Set();
-      if (dependents.has(property)) {
-        dependents.get(property).forEach(dependent => {
-          invalidProperties.add(dependent);
-          const newSet = this.invalidateProperty(dependents, dependent);
-          for (const invalidProperty of newSet) {
-            invalidProperties.add(invalidProperty);
-          }
-        });
-      }
-      return invalidProperties;
-    }
-
-    static resolveInvalidProperties(
-      dependencies,
-      resolvers,
-      invalidProperties
-    ) {
-      // Recursively resolve invalidity tree.
-      const remainingInvalidProperties = new Set();
-      for (const property of invalidProperties) {
-        let canResolve = true;
-        for (const dependency of dependencies.get(property)) {
-          if (invalidProperties.has(dependency)) {
-            canResolve = false;
-            break;
-          }
-        }
-        if (canResolve) {
-          resolvers.get(property)();
-        } else {
-          remainingInvalidProperties.add(property);
-        }
-      }
-      if (remainingInvalidProperties.size) {
-        this.resolveInvalidProperties(
-          dependencies,
-          resolvers,
-          remainingInvalidProperties
-        );
-      }
-    }
-
-    static resolveMethodName(target, methodName) {
-      // Prioritize instance over static.
-      const ctor = target.constructor;
-      if (target[methodName] instanceof Function) {
-        return { method: target[methodName], thisArg: target };
-      } else if (ctor[methodName] instanceof Function) {
-        return { method: ctor[methodName], thisArg: ctor };
-      } else {
-        const err = new Error(`Cannot resolve methodName "${methodName}".`);
-        target.dispatchError(err);
-      }
     }
 
     static dashToCamelCase(dash) {

--- a/mixins/property-effects-mixin.js
+++ b/mixins/property-effects-mixin.js
@@ -1,0 +1,240 @@
+/**
+ * Add effects that happen after a property is set: observer, computed, reflect.
+ */
+import Graph from '../etc/graph.js';
+
+const COMPUTED_REGEX = /^(.+)\((.+)\)$/;
+const COMPUTED_INFO = Symbol.for('__computedInfo__');
+const COMPUTE_READY = Symbol.for('__computeReady__');
+const OBSERVE_READY = Symbol.for('__observeReady__');
+const REFLECT_READY = Symbol.for('__reflectReady__');
+
+export default superclass =>
+  class extends superclass {
+    static parseComputed(computed) {
+      // Parse computed DSL. E.g., "myFunction(propertyOne, propertyTwo)".
+      const match = computed.match(COMPUTED_REGEX);
+      if (match) {
+        const [methodName, argsString = ''] = match.slice(1);
+        const dependencies = argsString.split(',').map(dep => dep.trim());
+        return { methodName, dependencies };
+      }
+    }
+
+    static resolveMethodName(target, methodName) {
+      // Look for method on instance and then on constructor.
+      if (target[methodName] instanceof Function) {
+        return target[methodName].bind(target);
+      } else if (target.constructor[methodName] instanceof Function) {
+        return target.constructor[methodName].bind(target.constructor);
+      } else {
+        const err = new Error(`Cannot resolve methodName "${methodName}".`);
+        target.dispatchError(err);
+      }
+    }
+
+    static createComputedCallback(target, property, methodName, dependencies) {
+      const method = this.resolveMethodName(target, methodName);
+      if (method) {
+        return skipIfUndefined => {
+          // Get definition at runtime in case things changed during analysis.
+          const definition = target.propertyDefinitions[property];
+          const args = dependencies.map(dependency => target[dependency]);
+          if (!skipIfUndefined || args.some(arg => arg !== undefined)) {
+            const value = this.applyType(method(...args), definition.type);
+            this.changeProperty(target, property, definition, value);
+          }
+        };
+      }
+    }
+
+    static analyzeObserverProperty(target, property, definition) {
+      if (definition.observer) {
+        const methodName = definition.observer;
+        const method = this.resolveMethodName(target, methodName);
+        if (method) {
+          return Object.assign({}, definition, { observe: method });
+        }
+      }
+      return definition;
+    }
+
+    static analyzeComputedProperty(target, property, definition) {
+      const computedInfo = target[COMPUTED_INFO];
+      if (computedInfo) {
+        const { dependencyToDependents, dependentToCallback } = computedInfo;
+        if (property in dependencyToDependents && !definition.computed) {
+          const sorted = Graph.sort(
+            Graph.createFromNodeMapping(property, dependencyToDependents)
+          );
+          if (sorted) {
+            const callbacks = sorted
+              .map(dependent => dependentToCallback[dependent])
+              .filter(callback => callback);
+            if (callbacks.length > 0) {
+              const compute = () => callbacks.forEach(callback => callback());
+              return Object.assign({}, definition, { compute });
+            }
+          }
+        } else if (definition.computed) {
+          return Object.assign({}, definition, { readOnly: true });
+        }
+      }
+      return definition;
+    }
+
+    static analyzeComputedProperties(target, properties) {
+      const dependencyToDependents = {};
+      const dependentToCallback = {};
+
+      let hasComputedProperties = false;
+      for (const [property, definition] of Object.entries(properties)) {
+        if (definition.computed) {
+          hasComputedProperties = true;
+          const { computed } = definition;
+          const parsedComputed = this.parseComputed(computed);
+          if (parsedComputed) {
+            const { methodName, dependencies } = parsedComputed;
+            for (const dependency of dependencies) {
+              if (dependency in properties === false) {
+                const err = new Error(`Missing dependency "${dependency}".`);
+                target.dispatchError(err);
+              }
+            }
+            const callback = this.createComputedCallback(
+              target,
+              property,
+              methodName,
+              dependencies
+            );
+            if (callback) {
+              dependentToCallback[property] = callback;
+            }
+            for (const dependency of dependencies) {
+              if (dependency in dependencyToDependents === false) {
+                dependencyToDependents[dependency] = [];
+              }
+              if (property in dependencyToDependents[dependency] === false) {
+                dependencyToDependents[dependency].push(property);
+              }
+            }
+          } else {
+            const err = new Error(`Malformed computed "${computed}".`);
+            target.dispatchError(err);
+          }
+        }
+      }
+
+      if (hasComputedProperties) {
+        target[COMPUTED_INFO] = {
+          dependencyToDependents,
+          dependentToCallback,
+        };
+
+        // We also need to initialize our computed props. We set that up here.
+        const nodes = Array.from(Object.keys(properties));
+        const edges = [];
+        const entries = Object.entries(dependencyToDependents);
+        for (const [dependency, dependents] of entries) {
+          edges.push(...dependents.map(dependent => [dependency, dependent]));
+        }
+        const sorted = Graph.sort(new Graph(nodes, edges));
+        if (sorted) {
+          const callbacks = sorted
+            .map(dependent => dependentToCallback[dependent])
+            .filter(callback => callback);
+          if (callbacks.length > 0) {
+            // The "true" arg skips callback if dependencies are all undefined.
+            // TODO: #27: skip initial compute if dependencies are all undefined
+            //  pass "true" arg to each callback to accomplish this.
+            target[COMPUTED_INFO].initialCompute = () =>
+              callbacks.forEach(callback => callback());
+          }
+        } else {
+          target.dispatchError(new Error('Computed properties are cyclic.'));
+        }
+      }
+    }
+
+    static analyzeProperties(target, properties) {
+      // Computed properties need to be analyzed altogether since it's a graph.
+      this.analyzeComputedProperties(target, properties);
+      super.analyzeProperties(target, properties);
+    }
+
+    static analyzeProperty(target, property, definition) {
+      let next = super.analyzeProperty(target, property, definition);
+      next = this.analyzeObserverProperty(target, property, next);
+      return this.analyzeComputedProperty(target, property, next);
+    }
+
+    static serializeProperty(target, property, definition, value) {
+      switch (definition.type.name) {
+        case 'Boolean':
+          return value ? '' : undefined;
+        case 'String':
+        case 'Number':
+          return value != null ? value.toString() : undefined;
+        default:
+          const message =
+            `Attempted to serialize "${property}" and reflect, but it is not ` +
+            `a Boolean, String, or Number type (${definition.type.name}).`;
+          target.dispatchError(new Error(message));
+      }
+    }
+
+    static reflectPropertyToAttribute(target, property, definition, value) {
+      const attribute = this.camelToDashCase(property);
+      const serialization = this.serializeProperty(
+        target,
+        property,
+        definition,
+        value
+      );
+      if (serialization === undefined) {
+        target.removeAttribute(attribute);
+      } else {
+        target.setAttribute(attribute, serialization);
+      }
+    }
+
+    static beforeInitialRender(target) {
+      super.beforeInitialRender(target);
+      target[COMPUTE_READY] = true;
+      if (target[COMPUTED_INFO] && target[COMPUTED_INFO].initialCompute) {
+        target[COMPUTED_INFO].initialCompute();
+      }
+    }
+
+    static afterInitialRender(target) {
+      super.afterInitialRender(target);
+      target[REFLECT_READY] = true;
+      target[OBSERVE_READY] = true;
+      const entries = Object.entries(target.propertyDefinitions);
+      for (const [property, definition] of entries) {
+        const value = target[property];
+        if (definition.reflect && value !== undefined) {
+          this.reflectPropertyToAttribute(target, property, definition, value);
+        }
+        if (definition.observe && value !== undefined) {
+          // TODO: #26: switch order of arguments.
+          definition.observe(undefined, value);
+        }
+      }
+      delete target[COMPUTED_INFO];
+    }
+
+    static propertyDidChange(target, property, definition, value, oldValue) {
+      super.propertyDidChange(target, property, definition, value, oldValue);
+      if (definition.reflect && target[REFLECT_READY]) {
+        this.reflectPropertyToAttribute(target, property, definition, value);
+      }
+      if (definition.observe && target[OBSERVE_READY]) {
+        // TODO: #26: switch order of arguments.
+        definition.observe(oldValue, value);
+      }
+      if (definition.compute && target[COMPUTE_READY]) {
+        definition.compute();
+      }
+    }
+  };

--- a/package.json
+++ b/package.json
@@ -13,14 +13,12 @@
     "lint-strict": "eslint ."
   },
   "files": [
-    "/mixins/element-mixin.js",
-    "/mixins/lit-html-mixin.js",
-    "/mixins/properties-mixin.js",
     "/x-element.js",
     "/x-element-basic.js",
     "/x-element-properties.js",
     "/etc",
     "/demo",
+    "/mixins",
     "/test",
     "/index.html",
     "/index.js",

--- a/test/fixture-element-computed-properties.js
+++ b/test/fixture-element-computed-properties.js
@@ -1,5 +1,7 @@
 import XElementProperties from '../x-element-properties.js';
 
+let count = 0;
+
 class TestElementComputedProperties extends XElementProperties {
   static get properties() {
     return {
@@ -27,16 +29,50 @@ class TestElementComputedProperties extends XElementProperties {
         type: Boolean,
         reflect: true,
       },
+      y: {
+        type: Boolean,
+      },
+      z: {
+        type: Boolean,
+        computed: 'computeZ(y)',
+      },
+      today: {
+        type: Date,
+      },
+      tomorrow: {
+        type: Date,
+        computed: 'computeTomorrow(today)',
+      },
+      countTrigger: {
+        type: String,
+      },
+      count: {
+        type: Number,
+        computed: 'computeCount(countTrigger)',
+        value: count,
+      },
     };
   }
   computeC(a, b) {
     return a + b;
   }
-  computeNegative(c) {
+  static computeNegative(c) {
     return c < 0;
+  }
+  static computeCount() {
+    // This doesn't use an observer to prevent a coupled test.
+    return ++count;
   }
   static computeUnderline(negative) {
     return !!negative;
+  }
+  static computeZ(y) {
+    return y;
+  }
+  static computeTomorrow(today) {
+    if (today) {
+      return today.valueOf() + 1000 * 60 * 60 * 24;
+    }
   }
   static template() {
     return ({ a, b, c }) => {
@@ -65,4 +101,44 @@ class TestElementComputedProperties extends XElementProperties {
 customElements.define(
   'test-element-computed-properties',
   TestElementComputedProperties
+);
+
+class TestElementComputedPropertiesErrors extends XElementProperties {
+  static get properties() {
+    return {
+      malformed: {
+        type: Boolean,
+        computed: 'thisMalformed!!!',
+      },
+      dne: {
+        type: Boolean,
+        computed: 'thisDNE(malformed)',
+      },
+      missing: {
+        type: String,
+        computed: 'computeMissing(notDeclared)',
+      },
+      zz: {
+        type: Boolean,
+      },
+      cyclic: {
+        type: String,
+        computed: 'computeCyclic(zz, cyclic)',
+      },
+    };
+  }
+  static computeMissing(notDeclared) {
+    return `this is just here to get past the unresolved method check`;
+  }
+  static computeCyclic(zz, cyclic) {
+    return `this is just here to get past the unresolved method check`;
+  }
+  static template() {
+    return () => ``;
+  }
+}
+
+customElements.define(
+  'test-element-computed-properties-errors',
+  TestElementComputedPropertiesErrors
 );

--- a/test/fixture-element-observed-properties.js
+++ b/test/fixture-element-observed-properties.js
@@ -24,28 +24,36 @@ class TestElementObservedProperties extends XElementProperties {
         reflect: true,
         observer: 'observePopped',
       },
+      dne: {
+        type: Boolean,
+        observer: 'thisDNE',
+      },
     };
   }
   computeC(a, b) {
     return `${a} ${b}`;
   }
+  // TODO: #26: switch order of arguments.
   observeA(oldValue, newValue) {
-    const changes = this.changes || [];
+    const changes = Object.assign([], this.changes);
     changes.push({ property: 'a', newValue, oldValue });
     this.changes = changes;
   }
+  // TODO: #26: switch order of arguments.
   observeB(oldValue, newValue) {
-    const changes = this.changes || [];
+    const changes = Object.assign([], this.changes);
     changes.push({ property: 'b', newValue, oldValue });
     this.changes = changes;
   }
+  // TODO: #26: switch order of arguments.
   observeC(oldValue, newValue) {
-    const changes = this.changes || [];
+    const changes = Object.assign([], this.changes);
     changes.push({ property: 'c', newValue, oldValue });
     this.changes = changes;
   }
+  // TODO: #26: switch order of arguments.
   observePopped(oldValue, newValue) {
-    const changes = this.changes || [];
+    const changes = Object.assign([], this.changes);
     changes.push({ property: 'popped', newValue, oldValue });
     this.changes = changes;
   }

--- a/test/fixture-element-read-only-properties.js
+++ b/test/fixture-element-read-only-properties.js
@@ -1,0 +1,31 @@
+import XElementProperties from '../x-element-properties.js';
+
+class TestElement extends XElementProperties {
+  static template() {
+    return ({ readOnlyProperty }) => `
+      <div id="container">
+        <span id="read-only-property">${readOnlyProperty}</span>
+      </div>
+    `;
+  }
+
+  static get properties() {
+    return {
+      readOnlyProperty: {
+        type: String,
+        readOnly: true,
+      },
+    };
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    // TODO: improve interface for readOnly properties.
+    const property = 'readOnlyProperty';
+    const definition = this.propertyDefinitions[property];
+    const value = 'Ferus';
+    this.constructor.changeProperty(this, property, definition, value);
+  }
+}
+
+customElements.define('test-element-read-only-properties', TestElement);

--- a/test/fixture-element-scratch.js
+++ b/test/fixture-element-scratch.js
@@ -96,7 +96,14 @@ class TestElement extends XElement {
           return new Map();
         },
       },
+      computedProp: {
+        type: String,
+        computed: 'computeComputedProp(prop1, prop2)',
+      },
     };
+  }
+  static computeComputedProp(prop1, prop2) {
+    return `${prop1} ${prop2}`;
   }
 }
 

--- a/test/fixture-element-upgrade.js
+++ b/test/fixture-element-upgrade.js
@@ -1,0 +1,35 @@
+import XElementBasic from '../x-element-basic.js';
+
+export default class TestElement extends XElementBasic {
+  constructor() {
+    super();
+    this._readOnlyProperty = 'didelphidae';
+    this._readOnlyKey = 'didelphimorphia';
+    Reflect.defineProperty(this, 'readOnlyDefinedProperty', {
+      value: 'phalangeriformes',
+      configurable: false,
+    });
+  }
+
+  static template() {
+    return ({ readOnlyProperty }) => `<div>${readOnlyProperty}</div>`;
+  }
+
+  get readOnlyProperty() {
+    return this._readOnlyProperty;
+  }
+
+  get [Symbol.for('readOnlyKey')]() {
+    return this._readOnlyKey;
+  }
+
+  get reflectedProperty() {
+    return this.getAttribute('reflected-property');
+  }
+
+  set reflectedProperty(value) {
+    this.setAttribute('reflected-property', value);
+  }
+}
+
+// NOTE, this is not defined in this file on purpose.

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,11 @@
 import run from './runner.js';
 
+run('./test-upgrade.js');
 run('./test-basic.js');
 run('./test-attr-binding.js');
 run('./test-attr-reflection.js');
+run('./test-read-only-properties.js');
+run('./test-graph.js');
 run('./test-computed-properties.js');
 run('./test-observed-properties.js');
 run('./test-scratch.js');

--- a/test/test-attr-binding.js
+++ b/test/test-attr-binding.js
@@ -1,7 +1,10 @@
 import { suite, it } from './runner.js';
 import './fixture-element-attr-binding.js';
 
-suite('x-element property (unit)', async ctx => {
+suite('x-element property (unit)', ctx => {
+  document.onerror = evt => {
+    console.error(evt.error);
+  };
   const el = document.createElement('test-element-attr-binding');
   it(
     'converts dash to camel case',
@@ -15,6 +18,10 @@ suite('x-element property (unit)', async ctx => {
 });
 
 suite('x-element property binding', async ctx => {
+  document.onerror = evt => {
+    console.error(evt.error);
+  };
+
   const el = document.createElement('test-element-attr-binding');
   ctx.body.appendChild(el);
 
@@ -24,7 +31,6 @@ suite('x-element property binding', async ctx => {
     el.shadowRoot.querySelector('#nul').textContent === ''
   );
 
-  await el;
   it(
     'renders the initial value',
     el.shadowRoot.querySelector('#camel').textContent === 'Bactrian'
@@ -53,6 +59,10 @@ suite('x-element property binding', async ctx => {
 });
 
 suite('x-element attribute binding (2)', async ctx => {
+  document.onerror = evt => {
+    console.error(evt.error);
+  };
+
   const el = document.createElement('test-element-attr-binding');
   ctx.body.appendChild(el);
 
@@ -85,6 +95,9 @@ suite('x-element attribute binding (2)', async ctx => {
 });
 
 suite('x-element attribute binding (3)', async ctx => {
+  document.onerror = evt => {
+    console.error(evt.error);
+  };
   const el = document.createElement('test-element-attr-binding');
   ctx.body.appendChild(el);
 

--- a/test/test-attr-reflection.js
+++ b/test/test-attr-reflection.js
@@ -1,14 +1,16 @@
 import { suite, it } from './runner.js';
 import './fixture-element-attr-reflection.js';
 
-suite('x-element attribute reflection', ctx => {
+suite('x-element attribute reflection', async ctx => {
+  document.onerror = evt => {
+    console.error(evt.error);
+  };
   const el = document.createElement('test-element-attr-reflection');
   ctx.body.appendChild(el);
   it(
     'reflects initial value',
     el.getAttribute('camel-case-property') === 'reflectedCamel'
   );
-  el.render();
   it(
     'renders the template with the initial value',
     el.shadowRoot.querySelector('span').textContent === 'reflectedCamel'
@@ -22,11 +24,12 @@ suite('x-element attribute reflection', ctx => {
     el.hasAttribute('boolean-property-false') === false
   );
   el.camelCaseProperty = 'dromedary';
-  el.render();
   it(
-    'reflects next value',
-    el.getAttribute('camel-case-property') === 'dromedary'
+    'reflects next value, but should not have rendered change yet',
+    el.getAttribute('camel-case-property') === 'dromedary' &&
+      el.shadowRoot.querySelector('span').textContent === 'reflectedCamel'
   );
+  await el;
   it(
     'renders the template with the next value',
     el.shadowRoot.querySelector('span').textContent === 'dromedary'

--- a/test/test-basic.js
+++ b/test/test-basic.js
@@ -1,13 +1,17 @@
 import { suite, it } from './runner.js';
 import './fixture-element-basic.js';
 
-suite('x-element basic', ctx => {
+suite('x-element basic', async ctx => {
+  document.onerror = evt => {
+    console.error(evt.error);
+  };
   const el = document.createElement('test-element-basic');
   it(
     'upgrades the element with a shadowRoot',
     el.shadowRoot instanceof DocumentFragment
   );
   ctx.body.appendChild(el);
+  await el;
   it(
     'renders the template with variables',
     el.shadowRoot.querySelector('span').textContent === 'Hello world.'
@@ -23,6 +27,9 @@ suite('x-element basic', ctx => {
 });
 
 suite('x-element basic (Boolean)', ctx => {
+  document.onerror = evt => {
+    console.error(evt.error);
+  };
   const el = document.createElement('test-element-basic');
   ctx.body.appendChild(el);
   el.booleanProperty = true;

--- a/test/test-computed-properties.js
+++ b/test/test-computed-properties.js
@@ -1,33 +1,127 @@
 import { suite, it } from './runner.js';
 import './fixture-element-computed-properties.js';
 
-suite('x-element computed properties', async ctx => {
+suite('x-element computed properties', ctx => {
+  // Test errors
+  const malformedMessage = `Malformed computed "thisMalformed!!!".`;
+  const unresolvedMessage = `Cannot resolve methodName "thisDNE".`;
+  const missingMessage = `Missing dependency "notDeclared".`;
+  const cyclicMessage = 'Computed properties are cyclic.';
+
+  let malformed = false;
+  let unresolved = false;
+  let missing = false;
+  let cyclic = false;
+
+  const onErrorTest = evt => {
+    if (evt.error.message === malformedMessage) {
+      malformed = true;
+    } else if (evt.error.message === unresolvedMessage) {
+      unresolved = true;
+    } else if (evt.error.message === missingMessage) {
+      missing = true;
+    } else if (evt.error.message === cyclicMessage) {
+      cyclic = true;
+    } else {
+      console.error(evt.error);
+    }
+  };
+  document.addEventListener('error', onErrorTest);
+
+  ctx.body.appendChild(
+    document.createElement('test-element-computed-properties-errors')
+  );
+
+  it('should error for malformed computed DSL', malformed);
+
+  it('should error for unresolved method names', unresolved);
+
+  it('should error for missing dependencies', missing);
+
+  it('should error for cyclic dependency graphs', cyclic);
+
+  document.removeEventListener('error', onErrorTest);
+
+  // Test normal use case.
+  document.addEventListener('error', evt => console.error(evt.error));
   const el = document.createElement('test-element-computed-properties');
   ctx.body.appendChild(el);
 
-  await el;
   it(
     'initialized as expected',
     el.a === undefined &&
       el.b === undefined &&
-      Number.isNaN(el.c) === true &&
+      // TODO: #27: Don't initialize until at least one dependency is defined.
+      //  We should switch the "isNaN" check to the commented out one.
+      // el.c === undefined &&
+      Number.isNaN(el.c) &&
+      // TODO: #27: Don't initialize until at least one dependency is defined.
+      //  We should switch the "false" check to the commented out one.
+      // el.negative === undefined &&
       el.negative === false &&
-      el.underline === false
+      // TODO: #27: Don't initialize until at least one dependency is defined.
+      //  We should switch the "false" check to the commented out one.
+      // el.underline === undefined &&
+      el.underline === false &&
+      el.y === undefined &&
+      el.z === undefined &&
+      el.countTrigger === undefined &&
+      // TODO: #27: Don't initialize until at least one dependency is defined.
+      //  We should be able to get `0` back here eventually.
+      // el.count === 0
+      el.count === 1
   );
 
   el.a = 1;
   el.b = -2;
   it(
-    'properties are recomputed when dependencies change',
+    'properties are recomputed when dependencies change (0)',
     el.a === 1 &&
       el.b === -2 &&
       el.c === -1 &&
       el.negative === true &&
-      el.underline === true
+      el.underline === true &&
+      el.y === undefined &&
+      el.z === undefined
+  );
+
+  el.y = true;
+  it(
+    'properties are recomputed when dependencies change (1)',
+    el.a === 1 &&
+      el.b === -2 &&
+      el.c === -1 &&
+      el.negative === true &&
+      el.underline === true &&
+      el.y === true &&
+      el.z === true
+  );
+
+  el.y = false;
+  it(
+    'properties are recomputed when dependencies change (2)',
+    el.a === 1 &&
+      el.b === -2 &&
+      el.c === -1 &&
+      el.negative === true &&
+      el.underline === true &&
+      el.y === false &&
+      el.z === false
   );
 
   it(
     'computed properties can be reflected',
     el.hasAttribute('negative') && el.hasAttribute('underline')
   );
+
+  el.countTrigger = 'foo';
+  const count = el.count;
+  el.countTrigger = 'foo';
+  el.countTrigger = 'foo';
+  el.countTrigger = 'foo';
+  el.countTrigger = 'foo';
+  it('skips compute when dependencies are the same', count === el.count);
+
+  el.countTrigger = 'bar';
+  it('computes when dependencies change again', count === el.count - 1);
 });

--- a/test/test-graph.js
+++ b/test/test-graph.js
@@ -1,0 +1,130 @@
+import { suite, it } from './runner.js';
+import Graph from '../etc/graph.js';
+
+const graphsAreEqual = (a, b) => {
+  // Order of nodes and edges should not matter.
+  return (
+    a.nodes.length === b.nodes.length &&
+    a.nodes.every(n => b.nodes.includes(n)) &&
+    a.edges.length === b.edges.length &&
+    a.edges.every(ae => b.edges.find(be => be[0] === ae[0] && be[1] === ae[1]))
+  );
+};
+
+const checkSolution = (solution, graph) => {
+  // We have to have the same nodes in our solution as we do in the graph.
+  if (
+    solution.length !== graph.nodes.length ||
+    graph.nodes.some(node => solution.includes(node) === false)
+  ) {
+    return false;
+  }
+  // For each edge, "edge[0]" must precede "edge[1]" in "solution".
+  for (const edge of graph.edges) {
+    if (solution.indexOf(edge[1]) <= solution.indexOf(edge[0])) {
+      return false;
+    }
+  }
+  return true;
+};
+
+suite('Graph.createFromNodeMapping', () => {
+  // It's easier to think about dependencies this way, so we compute the define
+  // dependentToDependencies and compute dependencyToDependents.
+  const dependentToDependencies = {
+    b: ['a'],
+    c: ['a', 'b'],
+    d: ['b', 'c'],
+  };
+  const dependencyToDependents = {};
+  const entries = Object.entries(dependentToDependencies);
+  for (const [dependent, dependencies] of entries) {
+    for (const dependency of dependencies) {
+      if (dependency in dependencyToDependents === false) {
+        dependencyToDependents[dependency] = [];
+      }
+      dependencyToDependents[dependency].push(dependent);
+    }
+  }
+
+  const actual1 = Graph.createFromNodeMapping('a', dependencyToDependents);
+  const expected1 = {
+    edges: [['a', 'b'], ['b', 'c'], ['c', 'd'], ['b', 'd'], ['a', 'c']],
+    nodes: ['a', 'b', 'c', 'd'],
+  };
+  it('can create a graph for "a"', graphsAreEqual(actual1, expected1));
+
+  const actual2 = Graph.createFromNodeMapping('b', dependencyToDependents);
+  const expected2 = {
+    edges: [['b', 'c'], ['c', 'd'], ['b', 'd']],
+    nodes: ['b', 'c', 'd'],
+  };
+  it('can create a graph for "b"', graphsAreEqual(actual2, expected2));
+
+  const actual3 = Graph.createFromNodeMapping('a', { a: ['a'] });
+  const expected3 = { edges: [['a', 'a']], nodes: ['a'] };
+  it('handles simple cycles', graphsAreEqual(actual3, expected3));
+
+  const actual4 = Graph.createFromNodeMapping('a', {
+    a: ['b'],
+    b: ['c'],
+    c: ['a'],
+  });
+  const expected4 = {
+    edges: [['a', 'b'], ['b', 'c'], ['c', 'a']],
+    nodes: ['a', 'b', 'c'],
+  };
+  it('handles complex cycles', graphsAreEqual(actual4, expected4));
+});
+
+// Note that Directed Acyclic Graphs can have multiple, correct solutions.
+suite('Graph.sort (for handling computed property dependencies)', () => {
+  const graph1 = new Graph(['c', 'b', 'a'], [['a', 'b'], ['b', 'c']]);
+  const actual1 = Graph.sort(graph1);
+  const expected1 = ['a', 'b', 'c'];
+  it(
+    'can solve a simple graph',
+    checkSolution(expected1, graph1) && checkSolution(actual1, graph1)
+  );
+
+  const graph2 = new Graph(['a', 'b', 'c'], [['a', 'b']]);
+  const actual2 = Graph.sort(graph2);
+  const expected2 = ['c', 'a', 'b'];
+  it(
+    'can solve a disconnected graph',
+    checkSolution(expected2, graph2) && checkSolution(actual2, graph2)
+  );
+
+  const graph3 = new Graph(
+    ['a', 'b', 'c', 'd'],
+    [['a', 'b'], ['a', 'd'], ['b', 'd'], ['c', 'd']]
+  );
+  const actual3 = Graph.sort(graph3);
+  const expected3 = ['c', 'a', 'b', 'd'];
+  it(
+    'can solve a complex graph',
+    checkSolution(expected3, graph3) && checkSolution(actual3, graph3)
+  );
+
+  const graph4 = new Graph(['a'], [['a', 'a']]);
+  const actual4 = Graph.sort(graph4);
+  it('can find simple cycles', actual4 === undefined);
+
+  const graph5 = new Graph(
+    ['a', 'b', 'c', 'd'],
+    [['a', 'b'], ['b', 'c'], ['c', 'd'], ['d', 'b']]
+  );
+  const actual5 = Graph.sort(graph5);
+  it('can find complex cycles', actual5 === undefined);
+
+  const graph6 = new Graph(
+    ['prop1', 'prop2', 'prop3'],
+    [['prop1', 'prop2'], ['prop1', 'prop3'], ['prop2', 'prop3']]
+  );
+  const actual6 = Graph.sort(graph6);
+  const expected6 = ['prop1', 'prop2', 'prop3'];
+  it(
+    'can have anything for node names',
+    checkSolution(expected6, graph6) && checkSolution(actual6, graph6)
+  );
+});

--- a/test/test-observed-properties.js
+++ b/test/test-observed-properties.js
@@ -1,39 +1,161 @@
 import { suite, it } from './runner.js';
 import './fixture-element-observed-properties.js';
 
-suite('x-element observed properties', async ctx => {
+const isObject = obj => obj instanceof Object && obj !== null;
+const deepEqual = (a, b) => {
+  if (a === b) {
+    return true;
+  }
+  return (
+    isObject(a) &&
+    isObject(b) &&
+    // Note, we ignore non-enumerable properties (Symbols) here.
+    Object.keys(a).length === Object.keys(b).length &&
+    Object.keys(a).every(key => deepEqual(a[key], b[key]))
+  );
+};
+
+suite('x-element observed properties', ctx => {
+  const unresolvedMessage = `Cannot resolve methodName "thisDNE".`;
+
+  let unresolved = false;
+
+  document.onerror = evt => {
+    if (evt.error.message === unresolvedMessage) {
+      unresolved = true;
+    } else {
+      console.error(evt.error);
+    }
+  };
+
   const el = document.createElement('test-element-observed-properties');
   el.a = 'oh';
   el.b = 'hai';
 
   ctx.body.appendChild(el);
 
-  await el;
+  it('should error for unresolved method names', unresolved);
+
   it(
     'initialized as expected',
-    JSON.stringify(el.changes) ===
-      '[{"property":"a","newValue":"oh"},{"property":"b","newValue":"hai"},{"property":"c","newValue":"oh hai"}]'
+    deepEqual(el.changes, [
+      {
+        property: 'a',
+        newValue: 'oh',
+        oldValue: undefined,
+      },
+      {
+        property: 'b',
+        newValue: 'hai',
+        oldValue: undefined,
+      },
+      {
+        property: 'c',
+        newValue: 'oh hai',
+        oldValue: undefined,
+      },
+    ])
   );
 
   el.b = 'hey';
   it(
     'observers are called when properties change',
-    JSON.stringify(el.changes) ===
-      '[{"property":"a","newValue":"oh"},{"property":"b","newValue":"hai"},{"property":"c","newValue":"oh hai"},{"property":"b","newValue":"hey","oldValue":"hai"},{"property":"c","newValue":"oh hey","oldValue":"oh hai"}]'
+    deepEqual(el.changes, [
+      {
+        property: 'a',
+        newValue: 'oh',
+        oldValue: undefined,
+      },
+      {
+        property: 'b',
+        newValue: 'hai',
+        oldValue: undefined,
+      },
+      {
+        property: 'c',
+        newValue: 'oh hai',
+        oldValue: undefined,
+      },
+      {
+        property: 'b',
+        newValue: 'hey',
+        oldValue: 'hai',
+      },
+      {
+        property: 'c',
+        newValue: 'oh hey',
+        oldValue: 'oh hai',
+      },
+    ])
   );
 
   el.b = 'hey';
   it(
     'observers are not called when set property is the same',
-    JSON.stringify(el.changes) ===
-      '[{"property":"a","newValue":"oh"},{"property":"b","newValue":"hai"},{"property":"c","newValue":"oh hai"},{"property":"b","newValue":"hey","oldValue":"hai"},{"property":"c","newValue":"oh hey","oldValue":"oh hai"}]'
+    deepEqual(el.changes, [
+      {
+        property: 'a',
+        newValue: 'oh',
+        oldValue: undefined,
+      },
+      {
+        property: 'b',
+        newValue: 'hai',
+        oldValue: undefined,
+      },
+      {
+        property: 'c',
+        newValue: 'oh hai',
+        oldValue: undefined,
+      },
+      {
+        property: 'b',
+        newValue: 'hey',
+        oldValue: 'hai',
+      },
+      {
+        property: 'c',
+        newValue: 'oh hey',
+        oldValue: 'oh hai',
+      },
+    ])
   );
 
   el.popped = true;
   el.setAttribute('popped', 'still technically true');
   it(
     'no re-entrance for observed, reflected properties',
-    JSON.stringify(el.changes) ===
-      '[{"property":"a","newValue":"oh"},{"property":"b","newValue":"hai"},{"property":"c","newValue":"oh hai"},{"property":"b","newValue":"hey","oldValue":"hai"},{"property":"c","newValue":"oh hey","oldValue":"oh hai"},{"property":"popped","newValue":true}]'
+    deepEqual(el.changes, [
+      {
+        property: 'a',
+        newValue: 'oh',
+        oldValue: undefined,
+      },
+      {
+        property: 'b',
+        newValue: 'hai',
+        oldValue: undefined,
+      },
+      {
+        property: 'c',
+        newValue: 'oh hai',
+        oldValue: undefined,
+      },
+      {
+        property: 'b',
+        newValue: 'hey',
+        oldValue: 'hai',
+      },
+      {
+        property: 'c',
+        newValue: 'oh hey',
+        oldValue: 'oh hai',
+      },
+      {
+        property: 'popped',
+        newValue: true,
+        oldValue: undefined,
+      },
+    ])
   );
 });

--- a/test/test-read-only-properties.js
+++ b/test/test-read-only-properties.js
@@ -1,0 +1,16 @@
+import { suite, it } from './runner.js';
+import './fixture-element-read-only-properties.js';
+
+suite('x-element readOnly properties', async ctx => {
+  document.onerror = evt => {
+    console.error(evt.error);
+  };
+  const el = document.createElement('test-element-read-only-properties');
+  ctx.body.appendChild(el);
+
+  await el;
+  it('initialized as expected', el.readOnlyProperty === 'Ferus');
+
+  el.readOnlyProperty = 'Dromedary';
+  it('read-only properties cannot be changed', el.readOnlyProperty === 'Ferus');
+});

--- a/test/test-upgrade.js
+++ b/test/test-upgrade.js
@@ -1,0 +1,103 @@
+import { suite, it } from './runner.js';
+import TestElement from './fixture-element-upgrade.js';
+
+const setupEl = el => {
+  el.className = 'marsupialia';
+  el.readOnlyProperty = 'chlamyphoridae';
+  el[Symbol.for('readOnlyKey')] = 'dasypodidae';
+  el.reflectedProperty = 'plantigrade';
+};
+
+const hasNotUpgraded = el => {
+  return (
+    el instanceof HTMLElement &&
+    el instanceof TestElement === false &&
+    el.shadowRoot === null &&
+    el.getAttribute('class') === 'marsupialia' &&
+    el.readOnlyProperty === 'chlamyphoridae' &&
+    el[Symbol.for('readOnlyKey')] === 'dasypodidae' &&
+    el.readOnlyDefinedProperty === undefined &&
+    el.reflectedProperty === 'plantigrade' &&
+    el.getAttribute('reflected-property') === null
+  );
+};
+
+const hasUpgraded = el => {
+  // Properties are still shadowed after upgrade and before initialization.
+  return (
+    el instanceof TestElement &&
+    el.getAttribute('class') === 'marsupialia' &&
+    el.readOnlyProperty === 'didelphidae' &&
+    el[Symbol.for('readOnlyKey')] === 'didelphimorphia' &&
+    el.readOnlyDefinedProperty === 'phalangeriformes' &&
+    el.reflectedProperty === 'plantigrade' &&
+    el.getAttribute('reflected-property') === 'plantigrade'
+  );
+};
+
+suite('x-element upgrade lifecycle', ctx => {
+  const localName = 'test-element-upgrade';
+  it(
+    'localName is initially undefined',
+    customElements.get(localName) === undefined
+  );
+
+  const el1 = ctx.createElement(localName);
+  el1.id = 'el1';
+  setupEl(el1);
+  ctx.body.appendChild(el1);
+
+  const el2 = ctx.createElement(localName);
+  el2.id = 'el2';
+  setupEl(el2);
+
+  it(
+    'el1 is setup as expected',
+    el1.localName === localName &&
+      ctx.getElementById('el1') === el1 &&
+      hasNotUpgraded(el1)
+  );
+
+  it(
+    'el2 is setup as expected',
+    el1.localName === localName &&
+      ctx.getElementById('el2') === null &&
+      hasNotUpgraded(el2)
+  );
+
+  customElements.define(localName, TestElement);
+
+  const el3 = ctx.createElement(localName);
+  el3.id = 'el3';
+  el3.className = 'marsupialia';
+  el3.reflectedProperty = 'plantigrade';
+
+  const el4 = new TestElement();
+  el4.id = 'el4';
+  el4.className = 'marsupialia';
+  el4.reflectedProperty = 'plantigrade';
+
+  it(
+    'elements created after definition do not need upgrading',
+    hasUpgraded(el3) && hasUpgraded(el4)
+  );
+
+  it('element in document is upgraded upon definition', hasUpgraded(el1));
+  it(
+    'element in document synchronously renders',
+    el1.shadowRoot.textContent === 'didelphidae'
+  );
+
+  it('element out of document is still not upgraded', hasNotUpgraded(el2));
+  ctx.body.appendChild(el2);
+  it(
+    'element out of document upgrades/renders after being added',
+    el2.shadowRoot.textContent === 'didelphidae'
+  );
+
+  ctx.body.appendChild(el3);
+  it(
+    'element created after definition upgrades/renders after being added',
+    el3.shadowRoot.textContent === 'didelphidae'
+  );
+});

--- a/x-element-properties.js
+++ b/x-element-properties.js
@@ -1,8 +1,9 @@
 /**
- * Implements property to attribute reflection.
+ * Implements properties and property effects (computed, observer, reflect).
  */
 
 import ElementMixin from './mixins/element-mixin.js';
 import PropertiesMixin from './mixins/properties-mixin.js';
+import PropertyEffectsMixin from './mixins/property-effects-mixin.js';
 
-export default PropertiesMixin(ElementMixin(HTMLElement));
+export default PropertyEffectsMixin(PropertiesMixin(ElementMixin(HTMLElement)));

--- a/x-element.js
+++ b/x-element.js
@@ -10,5 +10,8 @@
 import ElementMixin from './mixins/element-mixin.js';
 import LitHtmlMixin from './mixins/lit-html-mixin.js';
 import PropertiesMixin from './mixins/properties-mixin.js';
+import PropertyEffectsMixin from './mixins/property-effects-mixin.js';
 
-export default LitHtmlMixin(PropertiesMixin(ElementMixin(HTMLElement)));
+export default LitHtmlMixin(
+  PropertyEffectsMixin(PropertiesMixin(ElementMixin(HTMLElement)))
+);


### PR DESCRIPTION
### Changes:

1. Postpone more work until initial connect (closes #14 & closes #22).
2. Upgrade all properties at initialization time (closes #15).
3. Initialize properties before initial render (closes #17).
4. Improve handling of property effects (closes #19).
3. Robustify test suite.

### Non-changes:

1. This should remain a drop-in replacement for the old*†

*functionally this is the case, I've uncovered some previously-silenced errors though.
†note that **reflection happens before observation** as a result of this change.
### Notes:

#### Mixin hierarchy

1. `element-mixin`: Provides base functionality.
2. `properties-mixin`: Allows you to declare the `properties` block.
3. `property-effects-mixin`: Allows you to declare effects that should happen when a property changes.
4. `lit-html-mixin`: Chooses `lit-html` as our templating engine.

It's currently the case that you can omit mixins from the tail, but things will break down if you choose to omit something from the middle/head. I.e., you cannot have `property-effects-mixin` without `properties-mixin`, but the other way around is OK.

#### Custom element conformance

Whatwg has a [nice list of things](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-conformance) which a custom element should conform to.

#### Polymer 3.0 behavior

We loosely conform to the behavior of Polymer since there is considerable road time on that interface. In general, we aim to provide some minimum subset of the behaviors found in that project. Here are a couple places where we still diverge:

1. Order of arguments in observer callback (this will be fixed later as it would case backwards incompatibility)
2. Computed properties are called when initial dependencies are undefined (this will be fixed later as it would case backwards incompatibility)
3. Type coercion happens on property set (this doesn't happen in Polymer where `type` is just used for serialization/deserialization)

Importantly, the following order of operations for initialization is meant to match:

1. constructor is called
2. minimal setup (just shadow root init)
3. initial connectedCallback
4. analyze properties
5. initialize properties (reconcile initial values and resolve computed properties)
6. initial render
7. initial reflection & observation

Then, for each subsequent property change:

1. reflect to attribute, if reflected
2. call observer, if it exists
3. compute dependent properties, if they exist (this can trigger further observations/reflections)

#### Handling dependency graphs

Consider the following properties:

```
{
  a: { type: Boolean },
  b: { type: Boolean, computed: 'computeB(a)' },
  c: { type: Boolean, computed: 'computeC(a, b)' }
}
```

The graph looks like this:

```
      a
   ↙     ↘
b     →    c
```

Previously, we were recursively walking the dependencies until some terminal condition was met. This change solves the graph up front so that future property-set operations are more deterministic.

Because our dependencies are really a directed, acyclic graph (DAG), the topological sorting algorithm will provide us with one (of many!) possible orders in which to traverse the edges of the graph. This allows us to move the burden of computed properties from _set_-time to _setup_-time.

For completeness, the solution to this graph is `[a, b, c]`. That means that if `a` changes, you need to then update `b` and then update `c`, in that order.

#### Vernacular

The following terms are thrown around in the code:

`setup`: This is construction-time work.
`initialization`: This happens during the _first_ `connectedCallback`.
`analysis`: This is property-centric and is a static analysis done as prerequisite for property initialization