### PR TITLE
Add a styles-mixin for sharing css sheets.

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -14,6 +14,12 @@ custom extension is supported.
 Provides base functionality for creating custom elements with shadow roots and
 hooks to re-render the element.
 
+### `styles-mixin`
+
+Provides a way to define and share styles across instances of `x-element` via a
+declarative `styles` block. Styles are converted from strings to `CSSStyleSheet`
+instances and the results are cached for all future usage.
+
 ### `properties-mixin`
 
 Allows you to declare the `properties` block. This leverages the `element-mixin`

--- a/mixins/styles-mixin.js
+++ b/mixins/styles-mixin.js
@@ -1,0 +1,27 @@
+/**
+ * Provides declarative 'listeners' block.
+ */
+
+const sheetMap = new Map();
+
+export default superclass =>
+  class extends superclass {
+    static get styles() {
+      // Array of css text strings.
+      return [];
+    }
+
+    static beforeInitialRender(target) {
+      super.beforeInitialRender(target);
+      target.shadowRoot.adoptedStyleSheets = this.styles.map(this.cssToSheet);
+    }
+
+    static cssToSheet(css) {
+      if (sheetMap.has(css) === false) {
+        const sheet = new CSSStyleSheet();
+        sheet.replaceSync(css);
+        sheetMap.set(css, sheet);
+      }
+      return sheetMap.get(css);
+    }
+  };

--- a/test/fixture-element-styles.js
+++ b/test/fixture-element-styles.js
@@ -1,0 +1,29 @@
+import ElementMixin from '../mixins/element-mixin.js';
+import StylesMixin from '../mixins/styles-mixin.js';
+
+// language=CSS
+const style = `
+  :host {
+    color: blue;
+  }
+`;
+
+class TestElement extends StylesMixin(ElementMixin(HTMLElement)) {
+  static get styles() {
+    return [style];
+  }
+
+  static template() {
+    return () => `
+      <style>
+        :host {
+          color: red;
+          text-decoration: underline;
+        }
+      </style>
+      I'm blue and underlined.
+    `;
+  }
+}
+
+customElements.define('test-element-styles', TestElement);

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@ import run from './runner.js';
 run('./test-upgrade.js');
 run('./test-basic.js');
 run('./test-listeners.js');
+run('./test-styles.js');
 run('./test-attr-binding.js');
 run('./test-attr-reflection.js');
 run('./test-read-only-properties.js');

--- a/test/test-styles.js
+++ b/test/test-styles.js
@@ -1,0 +1,22 @@
+import { suite, it } from './runner.js';
+import './fixture-element-styles.js';
+
+suite('x-element styles', async ctx => {
+  document.onerror = evt => {
+    console.error(evt.error);
+  };
+  const el = document.createElement('test-element-styles');
+  ctx.body.appendChild(el);
+  const computedStyle = window.getComputedStyle(el);
+
+  it(
+    'should have blue text from adoptedStyles',
+    computedStyle.getPropertyValue('color') === 'rgb(0, 0, 255)'
+  );
+
+  it(
+    'should have be underlines from local styles',
+    computedStyle.getPropertyValue('text-decoration') ===
+      'underline solid rgb(0, 0, 255)'
+  );
+});

--- a/x-element.js
+++ b/x-element.js
@@ -7,9 +7,12 @@ import ListenersMixin from './mixins/listeners-mixin.js';
 import LitHtmlMixin from './mixins/lit-html-mixin.js';
 import PropertiesMixin from './mixins/properties-mixin.js';
 import PropertyEffectsMixin from './mixins/property-effects-mixin.js';
+import StylesMixin from './mixins/styles-mixin.js';
 
 export default LitHtmlMixin(
   ListenersMixin(
-    PropertyEffectsMixin(PropertiesMixin(ElementMixin(HTMLElement)))
+    PropertyEffectsMixin(
+      PropertiesMixin(StylesMixin(ElementMixin(HTMLElement)))
+    )
   )
 );


### PR DESCRIPTION
This sorta piqued my interest today, so I wanted to see what it might look like to try and follow the guidelines put out in https://wicg.github.io/construct-stylesheets/.

This PR raises some interesting questions:

1. Can we / should we attempt to make these styles non-modifiable? There's a glaring issue here in that you cache mutable objects... I couldn't figure out how to prevent modification.
2. Should the interface be simple strings? I like the simplicity here and non-forkiness of it.