### PR TITLE
Throw halting errors during analysis

### DIFF
--- a/mixins/properties-mixin.js
+++ b/mixins/properties-mixin.js
@@ -96,12 +96,13 @@ export default superclass =>
       Reflect.defineProperty(target, property, { get, set, configurable });
     }
 
+    static setup(target) {
+      super.setup(target);
+      this.analyzeProperties(target, this.properties);
+    }
+
     static beforeInitialRender(target) {
       super.beforeInitialRender(target);
-
-      // Analysis may dispatchErrors, only do this after element is connected.
-      this.analyzeProperties(target, this.properties);
-
       // Only reflect attributes when the element is connected
       // See https://dom.spec.whatwg.org/#dom-node-isconnected
       const entries = Object.entries(target.propertyDefinitions);

--- a/test/fixture-element-computed-properties.js
+++ b/test/fixture-element-computed-properties.js
@@ -109,42 +109,57 @@ customElements.define(
   TestElementComputedProperties
 );
 
-class TestElementComputedPropertiesErrors extends XElementProperties {
+class TestElementComputedPropertiesErrorsMalformed extends XElementProperties {
   static get properties() {
-    return {
-      malformed: {
-        type: Boolean,
-        computed: 'malformed(a,,b)',
-      },
-      dne: {
-        type: Boolean,
-        computed: 'thisDNE(malformed)',
-      },
-      missing: {
-        type: String,
-        computed: 'computeMissing(notDeclared)',
-      },
-      zz: {
-        type: Boolean,
-      },
-      cyclic: {
-        type: String,
-        computed: 'computeCyclic(zz, cyclic)',
-      },
-    };
-  }
-  static computeMissing(notDeclared) {
-    return `this is just here to get past the unresolved method check`;
-  }
-  static computeCyclic(zz, cyclic) {
-    return `this is just here to get past the unresolved method check`;
-  }
-  static template() {
-    return () => ``;
+    return { malformed: { type: Boolean, computed: 'malformed(a,,b)' } };
   }
 }
-
 customElements.define(
-  'test-element-computed-properties-errors',
-  TestElementComputedPropertiesErrors
+  'test-element-computed-properties-errors-malformed',
+  TestElementComputedPropertiesErrorsMalformed
 );
+
+class TestElementComputedPropertiesErrorsUnresolved extends XElementProperties {
+  static get properties() {
+    return {
+      a: { type: String },
+      dne: { type: Boolean, computed: 'thisDNE(a)' },
+    };
+  }
+}
+customElements.define(
+  'test-element-computed-properties-errors-unresolved',
+  TestElementComputedPropertiesErrorsUnresolved
+);
+
+class TestElementComputedPropertiesErrorsMissing extends XElementProperties {
+  static get properties() {
+    return { missing: { type: String, computed: 'computeMissing(notHere)' } };
+  }
+  static computeMissing() {}
+}
+customElements.define(
+  'test-element-computed-properties-errors-missing',
+  TestElementComputedPropertiesErrorsMissing
+);
+
+class TestElementComputedPropertiesErrorsCyclic extends XElementProperties {
+  static get properties() {
+    return {
+      a: { type: Boolean },
+      cyclic: { type: Boolean, computed: 'computeCyclic(a, cyclic)' },
+    };
+  }
+  static computeCyclic() {}
+}
+customElements.define(
+  'test-element-computed-properties-errors-cyclic',
+  TestElementComputedPropertiesErrorsCyclic
+);
+
+export {
+  TestElementComputedPropertiesErrorsMalformed,
+  TestElementComputedPropertiesErrorsUnresolved,
+  TestElementComputedPropertiesErrorsMissing,
+  TestElementComputedPropertiesErrorsCyclic,
+};

--- a/test/fixture-element-observed-properties.js
+++ b/test/fixture-element-observed-properties.js
@@ -24,10 +24,6 @@ class TestElementObservedProperties extends XElementProperties {
         reflect: true,
         observer: 'observePopped',
       },
-      dne: {
-        type: Boolean,
-        observer: 'thisDNE',
-      },
     };
   }
   computeC(a, b) {
@@ -90,3 +86,16 @@ customElements.define(
   'test-element-observed-properties',
   TestElementObservedProperties
 );
+
+
+class TestElementObservedPropertiesErrorsUnresolved extends XElementProperties {
+  static get properties() {
+    return { dne: { type: Boolean, observer: 'thisDNE' } };
+  }
+}
+customElements.define(
+  'test-element-observed-properties-errors-unresolved',
+  TestElementObservedPropertiesErrorsUnresolved
+);
+
+export { TestElementObservedPropertiesErrorsUnresolved };

--- a/test/test-observed-properties.js
+++ b/test/test-observed-properties.js
@@ -1,5 +1,5 @@
 import { suite, it } from './runner.js';
-import './fixture-element-observed-properties.js';
+import { TestElementObservedPropertiesErrorsUnresolved } from './fixture-element-observed-properties.js';
 
 const isObject = obj => obj instanceof Object && obj !== null;
 const deepEqual = (a, b) => {
@@ -16,16 +16,17 @@ const deepEqual = (a, b) => {
 };
 
 suite('x-element observed properties', ctx => {
-  const unresolvedMessage = `Cannot resolve methodName "thisDNE".`;
-
+  // Test analysis-time errors.
   let unresolved = false;
+  try {
+    new TestElementObservedPropertiesErrorsUnresolved();
+  } catch (err) {
+    unresolved = err.message === `Cannot resolve methodName "thisDNE".`;
+  }
+  it('should error for unresolved method names', unresolved);
 
   document.onerror = evt => {
-    if (evt.error.message === unresolvedMessage) {
-      unresolved = true;
-    } else {
-      console.error(evt.error);
-    }
+    console.error(evt.error);
   };
 
   const el = document.createElement('test-element-observed-properties');
@@ -33,8 +34,6 @@ suite('x-element observed properties', ctx => {
   el.b = 'hai';
 
   ctx.body.appendChild(el);
-
-  it('should error for unresolved method names', unresolved);
 
   it(
     'initialized as expected',


### PR DESCRIPTION
This PR:

- updates the analysis phase to throw halting errors
- moves analysis into setup since we don't need to be connected to the DOM anymore.