### PR TITLE
Don’t observe unchanged, computed properties.

### DIFF
--- a/mixins/property-effects-mixin.js
+++ b/mixins/property-effects-mixin.js
@@ -49,8 +49,10 @@ export default superclass =>
           const definition = target.propertyDefinitions[property];
           const args = dependencies.map(dependency => target[dependency]);
           if (!skipIfUndefined || args.some(arg => arg !== undefined)) {
-            const value = this.applyType(method(...args), definition.type);
-            this.changeProperty(target, property, definition, value);
+            const rawValue = method(...args);
+            if (this.rawValueChanged(target, property, rawValue)) {
+              this.changeProperty(target, property, definition, rawValue);
+            }
           }
         };
       }

--- a/test/fixture-element-observed-properties.js
+++ b/test/fixture-element-observed-properties.js
@@ -24,10 +24,6 @@ class TestElementObservedProperties extends XElementProperties {
         reflect: true,
         observer: 'observePopped',
       },
-      dne: {
-        type: Boolean,
-        observer: 'thisDNE',
-      },
     };
   }
   computeC(a, b) {
@@ -89,4 +85,20 @@ class TestElementObservedProperties extends XElementProperties {
 customElements.define(
   'test-element-observed-properties',
   TestElementObservedProperties
+);
+
+class TestElementObservedPropertiesErrors extends XElementProperties {
+  static get properties() {
+    return {
+      dne: {
+        type: Boolean,
+        observer: 'thisDNE',
+      },
+    };
+  }
+}
+
+customElements.define(
+  'test-element-observed-properties-errors',
+  TestElementObservedPropertiesErrors
 );

--- a/test/test-observed-properties.js
+++ b/test/test-observed-properties.js
@@ -15,14 +15,12 @@ const deepEqual = (a, b) => {
   );
 };
 
-it('x-element observed properties', () => {
+it('throws expected errors', () => {
   const unresolvedMessage = `Cannot resolve methodName "thisDNE".`;
 
   let unresolved = false;
 
-  const el = document.createElement('test-element-observed-properties');
-  el.a = 'oh';
-  el.b = 'hai';
+  const el = document.createElement('test-element-observed-properties-errors');
 
   const onError = evt => {
     if (evt.error.message === unresolvedMessage) {
@@ -35,22 +33,29 @@ it('x-element observed properties', () => {
 
   document.body.appendChild(el);
   assert(unresolved, 'should error for unresolved method names');
+});
+
+it('x-element observed properties', () => {
+  const el = document.createElement('test-element-observed-properties');
+  el.a = '11';
+  el.b = '22';
+  document.body.appendChild(el);
 
   assert(
     deepEqual(el.changes, [
       {
         property: 'a',
-        newValue: 'oh',
+        newValue: '11',
         oldValue: undefined,
       },
       {
         property: 'b',
-        newValue: 'hai',
+        newValue: '22',
         oldValue: undefined,
       },
       {
         property: 'c',
-        newValue: 'oh hai',
+        newValue: '11 22',
         oldValue: undefined,
       },
     ]),
@@ -62,28 +67,28 @@ it('x-element observed properties', () => {
     deepEqual(el.changes, [
       {
         property: 'a',
-        newValue: 'oh',
+        newValue: '11',
         oldValue: undefined,
       },
       {
         property: 'b',
-        newValue: 'hai',
+        newValue: '22',
         oldValue: undefined,
       },
       {
         property: 'c',
-        newValue: 'oh hai',
+        newValue: '11 22',
         oldValue: undefined,
       },
       {
         property: 'b',
         newValue: 'hey',
-        oldValue: 'hai',
+        oldValue: '22',
       },
       {
         property: 'c',
-        newValue: 'oh hey',
-        oldValue: 'oh hai',
+        newValue: '11 hey',
+        oldValue: '11 22',
       },
     ]),
     'observers are called when properties change'
@@ -94,31 +99,68 @@ it('x-element observed properties', () => {
     deepEqual(el.changes, [
       {
         property: 'a',
-        newValue: 'oh',
+        newValue: '11',
         oldValue: undefined,
       },
       {
         property: 'b',
-        newValue: 'hai',
+        newValue: '22',
         oldValue: undefined,
       },
       {
         property: 'c',
-        newValue: 'oh hai',
+        newValue: '11 22',
         oldValue: undefined,
       },
       {
         property: 'b',
         newValue: 'hey',
-        oldValue: 'hai',
+        oldValue: '22',
       },
       {
         property: 'c',
-        newValue: 'oh hey',
-        oldValue: 'oh hai',
+        newValue: '11 hey',
+        oldValue: '11 22',
       },
     ]),
     'observers are not called when set property is the same'
+  );
+
+  el.a = 11;
+  assert(
+    deepEqual(el.changes, [
+      {
+        property: 'a',
+        newValue: '11',
+        oldValue: undefined,
+      },
+      {
+        property: 'b',
+        newValue: '22',
+        oldValue: undefined,
+      },
+      {
+        property: 'c',
+        newValue: '11 22',
+        oldValue: undefined,
+      },
+      {
+        property: 'b',
+        newValue: 'hey',
+        oldValue: '22',
+      },
+      {
+        property: 'c',
+        newValue: '11 hey',
+        oldValue: '11 22',
+      },
+      {
+        property: 'a',
+        newValue: '11',
+        oldValue: '11',
+      },
+    ]),
+    'observers are not called when set property does not cause computed change'
   );
 
   el.popped = true;
@@ -127,28 +169,33 @@ it('x-element observed properties', () => {
     deepEqual(el.changes, [
       {
         property: 'a',
-        newValue: 'oh',
+        newValue: '11',
         oldValue: undefined,
       },
       {
         property: 'b',
-        newValue: 'hai',
+        newValue: '22',
         oldValue: undefined,
       },
       {
         property: 'c',
-        newValue: 'oh hai',
+        newValue: '11 22',
         oldValue: undefined,
       },
       {
         property: 'b',
         newValue: 'hey',
-        oldValue: 'hai',
+        oldValue: '22',
       },
       {
         property: 'c',
-        newValue: 'oh hey',
-        oldValue: 'oh hai',
+        newValue: '11 hey',
+        oldValue: '11 22',
+      },
+      {
+        property: 'a',
+        newValue: '11',
+        oldValue: '11',
       },
       {
         property: 'popped',
@@ -156,6 +203,6 @@ it('x-element observed properties', () => {
         oldValue: undefined,
       },
     ]),
-    'no re-entrance for observed, reflected properties',
+    'no re-entrance for observed, reflected properties'
   );
 });


### PR DESCRIPTION
@klebba , this basically fixes an issue where you could observe a noop in a computed property. Consider the computed property:

```
computeC(a, b) {
  if (a && b) {
    return a + b;
  }
}
```

If `a` is falsey, changing `b` will have no effect on `c`. It was basically cases like these causing observers to be called when nothing has changed.

Note that I've got some tests for this, but I wrote them with the new test runner that we created, so you'll have to trust that I'll include that test when I get that testing PR merged.