### PR TITLE
Update x-test dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   },
   "devDependencies": {
     "@netflix/element-server": "^1.0.9",
+    "@netflix/x-test": "^1.0.0-rc.11",
     "eslint": "^6.0.1",
     "puppeteer": "^1.11.0",
-    "tap-parser": "^9.0.0",
-    "x-test-js": "^1.0.0-rc.1"
+    "tap-parser": "^9.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-import { test } from '../../../x-test-js/x-test.js';
+import { test } from '../../../@netflix/x-test/x-test.js';
 
 test('./test-upgrade.html');
 test('./test-basic.html');

--- a/test/test-attr-binding.js
+++ b/test/test-attr-binding.js
@@ -1,5 +1,5 @@
 import './fixture-element-attr-binding.js';
-import { assert, it } from '../../../x-test-js/x-test.js';
+import { assert, it } from '../../../@netflix/x-test/x-test.js';
 
 it('converts dash to camel case and back', () => {
   const el = document.createElement('test-element-attr-binding');

--- a/test/test-attr-reflection.js
+++ b/test/test-attr-reflection.js
@@ -1,4 +1,4 @@
-import { it, assert } from '../../../x-test-js/x-test.js';
+import { it, assert } from '../../../@netflix/x-test/x-test.js';
 import './fixture-element-attr-reflection.js';
 
 it('reflects initial value', () => {

--- a/test/test-basic.js
+++ b/test/test-basic.js
@@ -1,5 +1,5 @@
 import './fixture-element-basic.js';
-import { it, assert } from '../../../x-test-js/x-test.js';
+import { it, assert } from '../../../@netflix/x-test/x-test.js';
 
 it('upgrades the element with a shadowRoot', () => {
   const el = document.createElement('test-element-basic');

--- a/test/test-computed-properties.js
+++ b/test/test-computed-properties.js
@@ -1,4 +1,4 @@
-import { it, assert, todo } from '../../../x-test-js/x-test.js';
+import { it, assert, todo } from '../../../@netflix/x-test/x-test.js';
 import './fixture-element-computed-properties.js';
 
 const parsingTestCases = [

--- a/test/test-graph.js
+++ b/test/test-graph.js
@@ -1,4 +1,4 @@
-import { it, assert } from '../../../x-test-js/x-test.js';
+import { it, assert } from '../../../@netflix/x-test/x-test.js';
 import Graph from '../etc/graph.js';
 
 const graphsAreEqual = (a, b) => {

--- a/test/test-listeners.js
+++ b/test/test-listeners.js
@@ -1,4 +1,4 @@
-import { assert, it } from '../../../x-test-js/x-test.js';
+import { assert, it } from '../../../@netflix/x-test/x-test.js';
 import './fixture-element-listeners.js';
 
 it('test lifecycle', () => {

--- a/test/test-observed-properties.js
+++ b/test/test-observed-properties.js
@@ -1,4 +1,4 @@
-import { assert, it } from '../../../x-test-js/x-test.js';
+import { assert, it } from '../../../@netflix/x-test/x-test.js';
 import './fixture-element-observed-properties.js';
 
 const isObject = obj => obj instanceof Object && obj !== null;

--- a/test/test-read-only-properties.js
+++ b/test/test-read-only-properties.js
@@ -1,4 +1,4 @@
-import { assert, it } from '../../../x-test-js/x-test.js';
+import { assert, it } from '../../../@netflix/x-test/x-test.js';
 import './fixture-element-read-only-properties.js';
 
 it('x-element readOnly properties', async () => {

--- a/test/test-scratch.js
+++ b/test/test-scratch.js
@@ -1,4 +1,4 @@
-import { assert, it } from '../../../x-test-js/x-test.js';
+import { assert, it } from '../../../@netflix/x-test/x-test.js';
 import './fixture-element-scratch.js';
 
 it('scratch', async () => {

--- a/test/test-upgrade.js
+++ b/test/test-upgrade.js
@@ -1,4 +1,4 @@
-import { assert, it } from '../../../x-test-js/x-test.js';
+import { assert, it } from '../../../@netflix/x-test/x-test.js';
 import TestElement from './fixture-element-upgrade.js';
 
 const setupEl = el => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,11 @@
   dependencies:
     node-static "^0.7.10"
 
+"@netflix/x-test@^1.0.0-rc.11":
+  version "1.0.0-rc.11"
+  resolved "https://artifacts.netflix.com/api/npm/npm-netflix/@netflix/x-test/-/x-test-1.0.0-rc.11.tgz#b3b3bb9ea841afcbdd6186e145e2c5adc7410f50"
+  integrity sha1-s7O7nqhBr8vdYYbhReLFrcdBD1A=
+
 acorn-jsx@^5.0.0:
   version "5.0.1"
   resolved "https://artifacts.netflix.com/api/npm/npm-netflix/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
@@ -1060,11 +1065,6 @@ ws@^6.1.0:
   integrity sha1-RC/fCkftZPWbal2P8TD0dI7VJPs=
   dependencies:
     async-limiter "~1.0.0"
-
-x-test-js@^1.0.0-rc.1:
-  version "1.0.0-rc.1"
-  resolved "https://artifacts.netflix.com/api/npm/npm-netflix/x-test-js/-/x-test-js-1.0.0-rc.1.tgz#dfccee7dd923b597c9b0b1f83f22f34c47156083"
-  integrity sha1-38zufdkjtZfJsLH4PyLzTEcVYIM=
 
 yallist@^3.0.0:
   version "3.0.3"


### PR DESCRIPTION
X-test-js has a better home under the @netflix scope, we should use it.