### PR TITLE
Shorten warning messages.

### DIFF
--- a/test/test-analysis-errors.js
+++ b/test/test-analysis-errors.js
@@ -62,8 +62,8 @@ it('properties should not shadow prototype chain interface', () => {
     'Unexpected key "TestElement.properties.title" has attribute "title" which is related to the inherited property "title", behavior not guaranteed.',
   ];
   const consoleWarn = console.warn; // eslint-disable-line no-console
-  console.warn = error => { // eslint-disable-line no-console
-    messages.push(error.message);
+  console.warn = message => { // eslint-disable-line no-console
+    messages.push(message);
   };
   class TestElement extends XElement {
     static get properties() {
@@ -85,8 +85,8 @@ it('properties with related inherited, asymmetric attributes should not shadow',
     'Unexpected key "TestElement.properties.class" has attribute "class" which is related to the inherited property "className", behavior not guaranteed.',
   ];
   const consoleWarn = console.warn; // eslint-disable-line no-console
-  console.warn = error => { // eslint-disable-line no-console
-    messages.push(error.message);
+  console.warn = message => { // eslint-disable-line no-console
+    messages.push(message);
   };
   class TestElement extends XElement {
     static get properties() {
@@ -111,8 +111,8 @@ it('properties with related inherited attributes should not shadow', () => {
     'Unexpected key "TestElement.properties.role" has attribute "role" which is inherited, behavior not guaranteed.',
   ];
   const consoleWarn = console.warn; // eslint-disable-line no-console
-  console.warn = error => { // eslint-disable-line no-console
-    messages.push(error.message);
+  console.warn = message => { // eslint-disable-line no-console
+    messages.push(message);
   };
   class TestElement extends XElement {
     static get properties() {
@@ -133,8 +133,8 @@ it('properties should not shadow data-* attribute interface', () => {
     'Unexpected key "TestElement.properties.dataFoo" has attribute "data-foo" which shadows data-* attribute interface, behavior not guaranteed.',
   ];
   const consoleWarn = console.warn; // eslint-disable-line no-console
-  console.warn = error => { // eslint-disable-line no-console
-    messages.push(error.message);
+  console.warn = message => { // eslint-disable-line no-console
+    messages.push(message);
   };
   class TestElement extends XElement {
     static get properties() {
@@ -159,8 +159,8 @@ it('properties should not shadow aria-* attribute interface', () => {
     'Unexpected key "TestElement.properties.ariaValueMin" has attribute "aria-value-min" which shadows aria-* attribute interface, behavior not guaranteed.',
   ];
   const consoleWarn = console.warn; // eslint-disable-line no-console
-  console.warn = error => { // eslint-disable-line no-console
-    messages.push(error.message);
+  console.warn = message => { // eslint-disable-line no-console
+    messages.push(message);
   };
   class TestElement extends XElement {
     static get properties() {

--- a/x-element.js
+++ b/x-element.js
@@ -304,20 +304,16 @@ export default class XElement extends HTMLElement {
         if (xElementPropertyName) {
           throw new Error(`Unexpected key "${path}.${key}" has attribute "${attribute}" which is related to an x-element property "${xElementPropertyName}".`);
         } else if (inheritedPropertyName) {
-          const error = new Error(`Unexpected key "${path}.${key}" has attribute "${attribute}" which is related to the inherited property "${inheritedPropertyName}", behavior not guaranteed.`);
-          console.warn(error); // eslint-disable-line no-console
+          console.warn(`Unexpected key "${path}.${key}" has attribute "${attribute}" which is related to the inherited property "${inheritedPropertyName}", behavior not guaranteed.`); // eslint-disable-line no-console
         } else {
-          const error = new Error(`Unexpected key "${path}.${key}" has attribute "${attribute}" which is inherited, behavior not guaranteed.`);
-          console.warn(error); // eslint-disable-line no-console
+          console.warn(`Unexpected key "${path}.${key}" has attribute "${attribute}" which is inherited, behavior not guaranteed.`); // eslint-disable-line no-console
         }
       }
       if (attribute.startsWith('aria-')) {
-        const error = new Error(`Unexpected key "${path}.${key}" has attribute "${attribute}" which shadows aria-* attribute interface, behavior not guaranteed.`);
-        console.warn(error); // eslint-disable-line no-console
+        console.warn(`Unexpected key "${path}.${key}" has attribute "${attribute}" which shadows aria-* attribute interface, behavior not guaranteed.`); // eslint-disable-line no-console
       }
       if (attribute.startsWith('data-')) {
-        const error = new Error(`Unexpected key "${path}.${key}" has attribute "${attribute}" which shadows data-* attribute interface, behavior not guaranteed.`);
-        console.warn(error); // eslint-disable-line no-console
+        console.warn(`Unexpected key "${path}.${key}" has attribute "${attribute}" which shadows data-* attribute interface, behavior not guaranteed.`); // eslint-disable-line no-console
       }
       attributes.add(attribute);
       if (Reflect.has(property, 'input')) {
@@ -347,11 +343,9 @@ export default class XElement extends HTMLElement {
       if (xElementPropertyName) {
         throw new Error(`Unexpected key "${path}" shadows in XElement.prototype interface.`);
       } else if (inheritedAttribute) {
-        const error = new Error(`Unexpected key "${path}" shadows related inherited attribute "${inheritedAttribute}", behavior not guaranteed.`);
-        console.warn(error); // eslint-disable-line no-console
+        console.warn(`Unexpected key "${path}" shadows related inherited attribute "${inheritedAttribute}", behavior not guaranteed.`); // eslint-disable-line no-console
       } else {
-        const error = new Error(`Unexpected key "${path}" shadows inherited interface, behavior not guaranteed.`);
-        console.warn(error); // eslint-disable-line no-console
+        console.warn(`Unexpected key "${path}" shadows inherited interface, behavior not guaranteed.`); // eslint-disable-line no-console
       }
     }
     for (const propertyKey of Object.keys(property)) {


### PR DESCRIPTION
We previously passed an Error into the console.warn call. However, the
stack trace isn’t actually helpful. Instead, we’ll just pass the error
message.

Closes #71