### PR TITLE
Relax access to internal properties.

### DIFF
--- a/test/test-analysis-errors.js
+++ b/test/test-analysis-errors.js
@@ -58,8 +58,8 @@ it('properties should not shadow XElement prototype interface', () => {
 it('properties should not shadow prototype chain interface', () => {
   const messages = [];
   const expectedMessages = [
-    'Unexpected key "TestElement.properties.title" shadows inherited interface, behavior not guaranteed.',
-    'Unexpected key "TestElement.properties.title" has attribute "title" which is related to the inherited property "title", behavior not guaranteed.',
+    'Unexpected key "TestElement.properties.title" shadows reserved interface, behavior not guaranteed.',
+    'Unexpected key "TestElement.properties.title" has attribute "title" which is related to the reserved property "title", behavior not guaranteed.',
   ];
   const consoleWarn = console.warn; // eslint-disable-line no-console
   console.warn = message => { // eslint-disable-line no-console
@@ -78,11 +78,11 @@ it('properties should not shadow prototype chain interface', () => {
   }
 });
 
-it('properties with related inherited, asymmetric attributes should not shadow', () => {
+it('properties with related reserved, asymmetric attributes should not shadow', () => {
   const messages = [];
   const expectedMessages = [
-    'Unexpected key "TestElement.properties.class" shadows related inherited attribute "class", behavior not guaranteed.',
-    'Unexpected key "TestElement.properties.class" has attribute "class" which is related to the inherited property "className", behavior not guaranteed.',
+    'Unexpected key "TestElement.properties.class" shadows related reserved attribute "class", behavior not guaranteed.',
+    'Unexpected key "TestElement.properties.class" has attribute "class" which is related to the reserved property "className", behavior not guaranteed.',
   ];
   const consoleWarn = console.warn; // eslint-disable-line no-console
   console.warn = message => { // eslint-disable-line no-console
@@ -103,12 +103,12 @@ it('properties with related inherited, asymmetric attributes should not shadow',
 
 // Depending on the browser, the errors might display slightly differently. It
 // should always complain though!
-it('properties with related inherited attributes should not shadow', () => {
+it('properties with related reserved attributes should not shadow', () => {
   const messages = [];
   const expectedMessages = [
-    'Unexpected key "TestElement.properties.role" shadows related inherited attribute "role", behavior not guaranteed.',
-    'Unexpected key "TestElement.properties.role" has attribute "role" which is related to the inherited property "role", behavior not guaranteed.',
-    'Unexpected key "TestElement.properties.role" has attribute "role" which is inherited, behavior not guaranteed.',
+    'Unexpected key "TestElement.properties.role" shadows related reserved attribute "role", behavior not guaranteed.',
+    'Unexpected key "TestElement.properties.role" has attribute "role" which is related to the reserved property "role", behavior not guaranteed.',
+    'Unexpected key "TestElement.properties.role" has attribute "role" which is reserved, behavior not guaranteed.',
   ];
   const consoleWarn = console.warn; // eslint-disable-line no-console
   console.warn = message => { // eslint-disable-line no-console
@@ -154,8 +154,8 @@ it('properties should not shadow data-* attribute interface', () => {
 it('properties should not shadow aria-* attribute interface', () => {
   const messages = [];
   const expectedMessages = [
-    'Unexpected key "TestElement.properties.ariaValueMin" shadows inherited interface, behavior not guaranteed.',
-    'Unexpected key "TestElement.properties.ariaValueMin" has attribute "aria-value-min" which is related to the inherited property "ariaValueMin", behavior not guaranteed.',
+    'Unexpected key "TestElement.properties.ariaValueMin" shadows reserved interface, behavior not guaranteed.',
+    'Unexpected key "TestElement.properties.ariaValueMin" has attribute "aria-value-min" which is related to the reserved property "ariaValueMin", behavior not guaranteed.',
     'Unexpected key "TestElement.properties.ariaValueMin" has attribute "aria-value-min" which shadows aria-* attribute interface, behavior not guaranteed.',
   ];
   const consoleWarn = console.warn; // eslint-disable-line no-console

--- a/test/test-attribute-changed-errors.js
+++ b/test/test-attribute-changed-errors.js
@@ -47,34 +47,7 @@ it('errors are thrown in attributeChangedCallback for read-only properties', () 
   try {
     el.attributeChangedCallback('read-only-property', null, 'nope');
   } catch (error) {
-    const expected = 'Property "TestElement.properties.readOnlyProperty" is read-only (internal.readOnlyProperty).';
-    message = error.message;
-    passed = error.message === expected;
-  }
-  assert(passed, message);
-});
-
-it('errors are thrown in attributeChangedCallback for internal properties', () => {
-  // We cannot try-catch setAttribute, so we fake the attributeChangedCallback.
-  class TestElement extends XElement {
-    static get properties() {
-      return {
-        internalProperty: {
-          type: String,
-          internal: true,
-        },
-      };
-    }
-  }
-  customElements.define('test-element-3', TestElement);
-  const el = new TestElement();
-  el.connectedCallback();
-  let passed = false;
-  let message = 'no error was thrown';
-  try {
-    el.attributeChangedCallback('internal-property', null, 'nope');
-  } catch (error) {
-    const expected = 'Property "TestElement.properties.internalProperty" is internal (internal.internalProperty).';
+    const expected = 'Property "TestElement.properties.readOnlyProperty" is read-only.';
     message = error.message;
     passed = error.message === expected;
   }
@@ -94,7 +67,7 @@ it('errors are thrown in attributeChangedCallback for computed properties', () =
       };
     }
   }
-  customElements.define('test-element-4', TestElement);
+  customElements.define('test-element-3', TestElement);
   const el = new TestElement();
   el.connectedCallback();
   let passed = false;

--- a/test/test-basic-properties.js
+++ b/test/test-basic-properties.js
@@ -89,7 +89,7 @@ it('property setter renders blank value', async () => {
   assert(el.shadowRoot.getElementById('camel').textContent === 'Bactrian');
 });
 
-it('observes all dash-cased versions of declared properties', () => {
+it('observes all dash-cased versions of public, declared properties', () => {
   const el = document.createElement('test-element');
   const expected = [
     'normal-property',
@@ -98,7 +98,6 @@ it('observes all dash-cased versions of declared properties', () => {
     'numeric-property',
     'null-property',
     'typeless-property',
-    'internal-property',
   ];
   const actual = el.constructor.observedAttributes;
   assert(expected.length === actual.length);

--- a/test/test-initialization-errors.js
+++ b/test/test-initialization-errors.js
@@ -47,34 +47,7 @@ it('errors are thrown in connectedCallback for initializing read-only properties
   try {
     el.connectedCallback();
   } catch (error) {
-    const expected = 'Property "TestElement.properties.readOnlyProperty" is read-only (internal.readOnlyProperty).';
-    message = error.message;
-    passed = error.message === expected;
-  }
-  assert(passed, message);
-});
-
-it('errors are thrown in connectedCallback for initializing internal properties', () => {
-  // We cannot try-catch append, so we fake the connectedCallback.
-  class TestElement extends XElement {
-    static get properties() {
-      return {
-        internalProperty: {
-          type: String,
-          internal: true,
-        },
-      };
-    }
-  }
-  customElements.define('test-element-2', TestElement);
-  const el = new TestElement();
-  el.internalProperty = 5;
-  let passed = false;
-  let message = 'no error was thrown';
-  try {
-    el.connectedCallback();
-  } catch (error) {
-    const expected = 'Property "TestElement.properties.internalProperty" is internal (internal.internalProperty).';
+    const expected = 'Property "TestElement.properties.readOnlyProperty" is read-only.';
     message = error.message;
     passed = error.message === expected;
   }
@@ -94,7 +67,7 @@ it('errors are thrown in connectedCallback for initializing computed properties'
       };
     }
   }
-  customElements.define('test-element-3', TestElement);
+  customElements.define('test-element-2', TestElement);
   const el = new TestElement();
   el.computed = 5;
   let passed = false;
@@ -126,14 +99,14 @@ it('errors are thrown in connectedCallback when template result fails to render'
       };
     }
   }
-  customElements.define('test-element-4', TestElement);
+  customElements.define('test-element-3', TestElement);
   const el = new TestElement();
   let passed = false;
   let message = 'no error was thrown';
   try {
     el.connectedCallback();
   } catch (error) {
-    const expected = ' — Invalid template for "TestElement" at path "test-element-4"';
+    const expected = ' — Invalid template for "TestElement" at path "test-element-3"';
     message = error.message;
     passed = error.message.endsWith(expected);
   }
@@ -157,7 +130,7 @@ it('errors are thrown in connectedCallback when template result fails to render 
       };
     }
   }
-  customElements.define('test-element-5', TestElement);
+  customElements.define('test-element-4', TestElement);
   const el = new TestElement();
   let passed = false;
   let message = 'no error was thrown';
@@ -169,7 +142,7 @@ it('errors are thrown in connectedCallback when template result fails to render 
   try {
     el.connectedCallback();
   } catch (error) {
-    const expected = ' — Invalid template for "TestElement" at path "test-element-5[id="testing"][class="foo bar"][boolean][variation="primary"]"';
+    const expected = ' — Invalid template for "TestElement" at path "test-element-4[id="testing"][class="foo bar"][boolean][variation="primary"]"';
     message = error.message;
     passed = error.message.endsWith(expected);
   }

--- a/test/test-internal-properties.js
+++ b/test/test-internal-properties.js
@@ -50,31 +50,18 @@ it('can use "ownKeys" api.', () => {
 it('cannot be read on host', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
-  let passed = false;
-  let message = 'no error was thrown';
-  try {
-    el.internalProperty;
-  } catch (error) {
-    const expected = 'Property "TestElement.properties.internalProperty" is internal (internal.internalProperty).';
-    message = error.message;
-    passed = error.message === expected;
-  }
-  assert(passed, message);
+  assert(el.internal.internalProperty === 'Ferus');
+  assert(el.internalProperty === undefined);
 });
 
 it('cannot be written to on host', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
-  let passed = false;
-  let message = 'no error was thrown';
-  try {
-    el.internalProperty = `don't do it`;
-  } catch (error) {
-    const expected = 'Property "TestElement.properties.internalProperty" is internal (internal.internalProperty).';
-    message = error.message;
-    passed = error.message === expected;
-  }
-  assert(passed, message);
+  assert(el.internal.internalProperty === 'Ferus');
+  assert(el.internalProperty === undefined);
+  el.internalProperty = 'ignored';
+  assert(el.internal.internalProperty === 'Ferus');
+  assert(el.internalProperty === 'ignored');
 });
 
 it('can be read from "internal"', () => {

--- a/test/test-read-only-properties.js
+++ b/test/test-read-only-properties.js
@@ -48,7 +48,7 @@ it('cannot be written to', () => {
   try {
     el.readOnlyProperty = `don't do it`;
   } catch (error) {
-    const expected = 'Property "TestElement.properties.readOnlyProperty" is read-only (internal.readOnlyProperty).';
+    const expected = 'Property "TestElement.properties.readOnlyProperty" is read-only.';
     message = error.message;
     passed = error.message === expected;
   }


### PR DESCRIPTION
Previously, to help developers, we threw errors when trying to set/get
attributes/properties for “internal” properties. Instead of shouting
about internals, we’re going to take a new tact — silence.

Setting/getting property values for internals will now _do nothing_.
This has the excellent side-effect of freeing up internal properties to
be named _anything_ since they’re safely name-spaced inside
“host.internal”.

E.g., you can now have an internal property called “title”, which
doesn’t interfere _at all_ with the inherited property “title”, nor the
inherited attribute “title”.

Closes #74.