### PR TITLE
Removes all “nudges” from “x-element”.

### DIFF
--- a/test/test-analysis-errors.js
+++ b/test/test-analysis-errors.js
@@ -25,7 +25,7 @@ it('property attributes should not have non-standard casing', () => {
   try {
     class TestElement extends XElement {
       static get properties() {
-        return { ok: { attribute: 'this-IS-not-OK'} };
+        return { ok: { type: String, attribute: 'this-IS-not-OK'} };
       }
     }
     customElements.define('test-element', TestElement);
@@ -53,126 +53,6 @@ it('properties should not shadow XElement prototype interface', () => {
     passed = error.message === expected;
   }
   assert(passed, message);
-});
-
-it('properties should not shadow prototype chain interface', () => {
-  const messages = [];
-  const expectedMessages = [
-    'Unexpected key "TestElement.properties.title" shadows reserved interface, behavior not guaranteed.',
-    'Unexpected key "TestElement.properties.title" has attribute "title" which is related to the reserved property "title", behavior not guaranteed.',
-  ];
-  const consoleWarn = console.warn; // eslint-disable-line no-console
-  console.warn = message => { // eslint-disable-line no-console
-    messages.push(message);
-  };
-  class TestElement extends XElement {
-    static get properties() {
-      return { title: {} };
-    }
-  }
-  customElements.define('test-element-warning-0', TestElement);
-  console.warn = consoleWarn; // eslint-disable-line no-console
-  assert(messages.length === expectedMessages.length);
-  for (let index = 0; index < messages.length; index++) {
-    assert(messages[index] === expectedMessages[index], `${index}::${messages[index]}`);
-  }
-});
-
-it('properties with related reserved, asymmetric attributes should not shadow', () => {
-  const messages = [];
-  const expectedMessages = [
-    'Unexpected key "TestElement.properties.class" shadows related reserved attribute "class", behavior not guaranteed.',
-    'Unexpected key "TestElement.properties.class" has attribute "class" which is related to the reserved property "className", behavior not guaranteed.',
-  ];
-  const consoleWarn = console.warn; // eslint-disable-line no-console
-  console.warn = message => { // eslint-disable-line no-console
-    messages.push(message);
-  };
-  class TestElement extends XElement {
-    static get properties() {
-      return { class: {} };
-    }
-  }
-  customElements.define('test-element-warning-1', TestElement);
-  console.warn = consoleWarn; // eslint-disable-line no-console
-  assert(messages.length === expectedMessages.length);
-  for (let index = 0; index < messages.length; index++) {
-    assert(messages[index] === expectedMessages[index], `${index}::${messages[index]}`);
-  }
-});
-
-// Depending on the browser, the errors might display slightly differently. It
-// should always complain though!
-it('properties with related reserved attributes should not shadow', () => {
-  const messages = [];
-  const expectedMessages = [
-    'Unexpected key "TestElement.properties.role" shadows related reserved attribute "role", behavior not guaranteed.',
-    'Unexpected key "TestElement.properties.role" has attribute "role" which is related to the reserved property "role", behavior not guaranteed.',
-    'Unexpected key "TestElement.properties.role" has attribute "role" which is reserved, behavior not guaranteed.',
-  ];
-  const consoleWarn = console.warn; // eslint-disable-line no-console
-  console.warn = message => { // eslint-disable-line no-console
-    messages.push(message);
-  };
-  class TestElement extends XElement {
-    static get properties() {
-      return { role: {} };
-    }
-  }
-  customElements.define('test-element-warning-2', TestElement);
-  console.warn = consoleWarn; // eslint-disable-line no-console
-  assert(messages.length > 0);
-  for (const message of messages) {
-    assert(expectedMessages.includes(message), message);
-  }
-});
-
-it('properties should not shadow data-* attribute interface', () => {
-  const messages = [];
-  const expectedMessages = [
-    'Unexpected key "TestElement.properties.dataFoo" has attribute "data-foo" which shadows data-* attribute interface, behavior not guaranteed.',
-  ];
-  const consoleWarn = console.warn; // eslint-disable-line no-console
-  console.warn = message => { // eslint-disable-line no-console
-    messages.push(message);
-  };
-  class TestElement extends XElement {
-    static get properties() {
-      return { dataFoo: {} };
-    }
-  }
-  customElements.define('test-element-warning-3', TestElement);
-  console.warn = consoleWarn; // eslint-disable-line no-console
-  assert(messages.length === expectedMessages.length);
-  for (let index = 0; index < messages.length; index++) {
-    assert(messages[index] === expectedMessages[index], `${index}::${messages[index]}`);
-  }
-});
-
-// Depending on the browser, the errors might display slightly differently. It
-// should always complain though!
-it('properties should not shadow aria-* attribute interface', () => {
-  const messages = [];
-  const expectedMessages = [
-    'Unexpected key "TestElement.properties.ariaValueMin" shadows reserved interface, behavior not guaranteed.',
-    'Unexpected key "TestElement.properties.ariaValueMin" has attribute "aria-value-min" which is related to the reserved property "ariaValueMin", behavior not guaranteed.',
-    'Unexpected key "TestElement.properties.ariaValueMin" has attribute "aria-value-min" which shadows aria-* attribute interface, behavior not guaranteed.',
-  ];
-  const consoleWarn = console.warn; // eslint-disable-line no-console
-  console.warn = message => { // eslint-disable-line no-console
-    messages.push(message);
-  };
-  class TestElement extends XElement {
-    static get properties() {
-      return { ariaValueMin: {} };
-    }
-  }
-  customElements.define('test-element-warning-4', TestElement);
-  console.warn = consoleWarn; // eslint-disable-line no-console
-  assert(messages.length > 0);
-  for (const message of messages) {
-    assert(expectedMessages.includes(message), message);
-  }
 });
 
 it('property keys should only be from our known set', () => {
@@ -307,7 +187,7 @@ it('attributes cannot be duplicated', () => {
   try {
     class TestElement extends XElement {
       static get properties() {
-        return { attribute: {}, aliased: { attribute: 'attribute' } };
+        return { attribute: { type: String }, aliased: { type: String, attribute: 'attribute' } };
       }
     }
     customElements.define('test-element', TestElement);

--- a/test/test-attribute-changed-errors.js
+++ b/test/test-attribute-changed-errors.js
@@ -1,32 +1,6 @@
 import XElement from '../x-element.js';
 import { assert, it } from '../../../@netflix/x-test/x-test.js';
 
-it('errors are thrown in attributeChangedCallback for setting values with bad types', () => {
-  // We cannot try-catch setAttribute, so we fake the attributeChangedCallback.
-  class TestElement extends XElement {
-    static get properties() {
-      return {
-        object: {
-          type: Object,
-        },
-      };
-    }
-  }
-  customElements.define('test-element-1', TestElement);
-  const el = new TestElement();
-  el.connectedCallback();
-  let passed = false;
-  let message = 'no error was thrown';
-  try {
-    el.attributeChangedCallback('object', null, '{}');
-  } catch (error) {
-    const expected = 'Unexpected deserialization for "TestElement.properties.object" (cannot deserialize into Object).';
-    message = error.message;
-    passed = error.message === expected;
-  }
-  assert(passed, message);
-});
-
 it('errors are thrown in attributeChangedCallback for read-only properties', () => {
   // We cannot try-catch setAttribute, so we fake the attributeChangedCallback.
   class TestElement extends XElement {

--- a/test/test-basic-properties.js
+++ b/test/test-basic-properties.js
@@ -89,15 +89,13 @@ it('property setter renders blank value', async () => {
   assert(el.shadowRoot.getElementById('camel').textContent === 'Bactrian');
 });
 
-it('observes all dash-cased versions of public, declared properties', () => {
+it('observes all dash-cased versions of public, serializable, and declared properties', () => {
   const el = document.createElement('test-element');
   const expected = [
     'normal-property',
-    'object-property',
     'camel-case-property',
     'numeric-property',
     'null-property',
-    'typeless-property',
   ];
   const actual = el.constructor.observedAttributes;
   assert(expected.length === actual.length);
@@ -147,9 +145,6 @@ it('allows properties without types', () => {
     el.typelessProperty = value;
     assert(el.typelessProperty === value);
   }
-  const attributeValue = 'attribute';
-  el.setAttribute('typeless-property', attributeValue);
-  assert(el.typelessProperty === attributeValue);
 });
 
 it('initializes from attributes on connect', () => {


### PR DESCRIPTION
There’s been a lot of discussion about the opinions “x-element” makes to
be helpful — and sometimes the accusation is that “x-element” is getting
in the way.

This PR removes _all_ such nudges. This should feel inline with our
choice to remove errors for attempting to access `internal` properties
on the host (e.g., `host.myInternalProp` just returns `undefined` now).

In particular, we no longer error for the following:

* If an attribute is set for an unserializable property — we no longer
  observe such attributes at all.

And, we no longer warn for the following:

* If you have a property that shadows the HTMLElement interface’s
  prototype chain — e.g., “title”, “draggable”, “role”, “dataset”,
  “style”, etc, etc. The assumption is that users of “x-element” are
  experts and they would only do this _on purpose_.
* If you have a property that shadows “data-*” attributes.
* If you have a property that shadows “aria-*” attributes.

Closes #77.