### PR TITLE
Setup listeners before initial render.

### DIFF
--- a/x-element.js
+++ b/x-element.js
@@ -118,8 +118,7 @@ export default class XElement extends HTMLElement {
 
   /** Extends HTMLElement.prototype.connectedCallback. */
   connectedCallback() {
-    XElement.#initializeHost(this);
-    XElement.#addListeners(this);
+    XElement.#connectHost(this);
   }
 
   /** Extends HTMLElement.prototype.attributeChangedCallback. */
@@ -135,7 +134,7 @@ export default class XElement extends HTMLElement {
 
   /** Extends HTMLElement.prototype.disconnectedCallback. */
   disconnectedCallback() {
-    XElement.#removeListeners(this);
+    XElement.#disconnectHost(this);
   }
 
   /**
@@ -686,6 +685,18 @@ export default class XElement extends HTMLElement {
   }
 
   // Called once per-host from initial "connectedCallback".
+  static #connectHost(host) {
+    const initialized = XElement.#initializeHost(host);
+    XElement.#addListeners(host);
+    if (initialized) {
+      XElement.#updateHost(host);
+    }
+  }
+
+  static #disconnectHost(host) {
+    XElement.#removeListeners(host);
+  }
+
   static #initializeHost(host) {
     const hostInfo = XElement.#hosts.get(host);
     const { initialized, invalidProperties } = hostInfo;
@@ -705,8 +716,9 @@ export default class XElement extends HTMLElement {
         invalidProperties.add(property);
       }
       hostInfo.initialized = true;
-      XElement.#updateHost(host);
+      return true;
     }
+    return false;
   }
 
   // Prevent shadowing from properties added to element instance pre-upgrade.


### PR DESCRIPTION
Previously, “initializeHost” was called ahead of “addListeners”. There was an edge case where such depth-first initialization made it possible for synchronous events from children to be emitted before the delegated event listeners had been setup on the parent.

This change ensures the following happens in order on first connection:
1. The host itself is initialized.
2. The static listeners are added.
3. The host undergoes its initial render.

Previously, (2) and (3) were conceptually swapped.