### PR TITLE
Skip initial lookup for internal properties.

### DIFF
--- a/test/test-internal-properties.js
+++ b/test/test-internal-properties.js
@@ -15,6 +15,13 @@ class TestElement extends XElement {
         input: ['internalProperty'],
         compute: internalProperty => internalProperty,
       },
+      // This exists on the public interface, we want to ensure that there's no
+      //  issue using this same name on the internal interface.
+      children: {
+        // Use a type that's in conflict with the public interface.
+        type: Boolean,
+        internal: true,
+      },
     };
   }
   static template(html) {
@@ -42,7 +49,10 @@ it('can use "ownKeys" api.', () => {
   document.body.append(el);
   const ownKeys = Reflect.ownKeys(el.internal);
   assert(
-    ownKeys.length === 2 && ownKeys[0] === 'internalProperty' && ownKeys[1] === 'internalComputedProperty',
+    ownKeys.length === 3 &&
+    ownKeys[0] === 'internalProperty' &&
+    ownKeys[1] === 'internalComputedProperty' &&
+    ownKeys[2] === 'children',
     'The "ownKeys" trap does not work.'
   );
 });

--- a/x-element.js
+++ b/x-element.js
@@ -735,16 +735,19 @@ export default class XElement extends HTMLElement {
     // Process possible sources of initial state, with this priority:
     // 1. imperative, e.g. `element.prop = 'value';`
     // 2. declarative, e.g. `<element prop="value"></element>`
-    const { key, attribute } = property;
+    const { key, attribute, internal } = property;
     let value;
     let found = false;
-    if (Reflect.has(host, key)) {
-      value = host[key];
-      found = true;
-    } else if (attribute && host.hasAttribute(attribute)) {
-      const attributeValue = host.getAttribute(attribute);
-      value = XElement.#deserializeProperty(host, property, attributeValue);
-      found = true;
+    if (!internal) {
+      // Only look for public (i.e., non-internal) properties.
+      if (Reflect.has(host, key)) {
+        value = host[key];
+        found = true;
+      } else if (attribute && host.hasAttribute(attribute)) {
+        const attributeValue = host.getAttribute(attribute);
+        value = XElement.#deserializeProperty(host, property, attributeValue);
+        found = true;
+      }
     }
     return { value, found };
   }


### PR DESCRIPTION
Internal properties should be completely decoupled from the public interface. This change set adds a guard to ensure that we don’t try to lookup the property name on the public interface when upgrading the element.

Closes #129.