### PR TITLE
Update dependencies for testing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "eslint": "^8.35.0",
     "http-server": "^14.1.1",
-    "puppeteer": "^13.4.0",
-    "tap-parser": "^10.0.1"
+    "puppeteer": "^19.7.5",
+    "tap-parser": "^12.0.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,10 @@
-import { test, cover } from './x-test.js';
+import { test, coverage } from './x-test.js';
 
 // We import this here so we can see code coverage.
 import '../x-element.js';
 
 // Set a high bar for code coverage!
-cover(new URL('../x-element.js', import.meta.url).href, 100);
+coverage(new URL('../x-element.js', import.meta.url).href, 100);
 
 test('./test-analysis-errors.html');
 test('./test-initialization-errors.html');

--- a/test/test-scratch.js
+++ b/test/test-scratch.js
@@ -1,5 +1,5 @@
 import XElement from '../x-element.js';
-import { assert, it, skip } from './x-test.js';
+import { assert, it } from './x-test.js';
 
 class TestElement extends XElement {
   static get properties() {
@@ -220,7 +220,7 @@ it('test dispatchError', () => {
 
 // TODO: Firefox somehow returns an un-upgraded instance after adoption. This
 //  seems like a bug in the browser, but we should look into it.
-(navigator.userAgent.includes('Firefox') ? skip : it)('test adoptedCallback', () => {
+(navigator.userAgent.includes('Firefox') ? it.skip : it)('test adoptedCallback', () => {
   const el = document.createElement('test-element');
   el.prop1 = 'adopt me!';
   document.body.append(el);

--- a/test/test-template-engine.js
+++ b/test/test-template-engine.js
@@ -1,5 +1,5 @@
 import XElement from '../x-element.js';
-import { assert, it, todo } from './x-test.js';
+import { assert, describe, it } from './x-test.js';
 
 // Long-term interface.
 const { render, html, svg, map, nullish } = XElement.templateEngine;
@@ -7,1544 +7,1572 @@ const { render, html, svg, map, nullish } = XElement.templateEngine;
 // Migration-related interface. We may or may not keep these.
 const { live, unsafeHTML, unsafeSVG, ifDefined, repeat } = XElement.templateEngine;
 
-it('html: renders basic string', () => {
-  const getTemplate = () => {
-    return html`<div id="target">No interpolation.</div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate());
-  assert(container.querySelector('#target').textContent === 'No interpolation.');
-  container.remove();
-});
-
-it('html: refuses to interpolate within a style tag', () => {
-  const getTemplate = ({ color }) => {
-    return html`
-      <style id="target">
-        #target {
-          background-color: ${color};
-        }
-      </style>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ color: 'url(evil-url)' }));
-  const textContent = container.querySelector('#target').textContent;
-  assert(textContent === '/* x-element: Interpolation is not allowed here. */', textContent);
-  container.remove();
-});
-
-it('html: refuses to interpolate within a script tag', () => {
-  const getTemplate = ({ message }) => {
-    return html`
-      <script id="target">
-        console.log('${message}');
-      </script>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ message: '\' + prompt(\'evil\') + \'' }));
-  const textContent = container.querySelector('#target').textContent;
-  assert(textContent === '/* x-element: Interpolation is not allowed here. */', textContent);
-  container.remove();
-});
-
-it('html: renders interpolated content without parsing', () => {
-  const userContent = '<a href="https://evil.com">Click Me!</a>';
-  const getTemplate = () => {
-    return html`<div id="target">${userContent}</div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate());
-  assert(container.querySelector('#target').textContent === userContent);
-  container.remove();
-});
-
-it('html: does not recognize single-quoted attributes', () => {
-  const getTemplate = () => {
-    return html`<div id="target" ignore-me='${'foo'}'>Gotta double-quote those.</div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate());
-  assert(container.querySelector('#target').getAttribute('ignore-me') !== 'foo');
-  container.remove();
-});
-
-it('html: does not recognize single-quoted properties', () => {
-  const getTemplate = () => {
-    return html`<div id="target" .ignoreMe='${'foo'}'>Gotta double-quote those.</div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate());
-  assert(container.querySelector('#target').ignoreMe !== 'foo');
-  container.remove();
-});
-
-it('html: refuses to reuse a template', () => {
-  const templateResultReference = html`<div id="target"></div>`;
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, templateResultReference);
-  assert(!!container.querySelector('#target'));
-  render(container, null);
-  assert(!container.querySelector('#target'));
-  let error;
-  try {
-    render(container, templateResultReference);
-  } catch (e) {
-    error = e;
-  }
-  assert(error?.message === 'Unexpected re-injection of template result.', error.message);
-  container.remove();
-});
-
-it('html: renders nullish templates', () => {
-  const getTemplate = () => {
-    return html`<div></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate());
-  assert(!!container.childNodes.length);
-  render(container, null);
-  assert(!container.childNodes.length);
-  render(container, getTemplate());
-  assert(!!container.childNodes.length);
-  render(container, undefined);
-  assert(!container.childNodes.length);
-  container.remove();
-});
-
-it('html: renders interpolated content', () => {
-  const getTemplate = ({ content }) => {
-    return html`<div id="target">${content}</div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ content: 'Interpolated.' }));
-  assert(container.querySelector('#target').textContent === 'Interpolated.');
-  render(container, getTemplate({ content: 'Updated.' }));
-  assert(container.querySelector('#target').textContent === 'Updated.');
-  container.remove();
-});
-
-it('html: renders multiple, interpolated content', () => {
-  const getTemplate = ({ one, two }) => {
-    return html`
-      <div id="target">one: ${one} / two: ${two}</div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ one: 'ONE', two: 'TWO' }));
-  assert(container.querySelector('#target').textContent === 'one: ONE / two: TWO');
-  container.remove();
-});
-
-it('html: renders nested content', () => {
-  const getTemplate = ({ show, nestedContent }) => {
-    return html`
-      <div id="target">
-        ${show ? html`<span id="conditional">${nestedContent}</span>` : null}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ show: true, nestedContent: 'oh hai' }));
-  assert(!!container.querySelector('#conditional'));
-  render(container, getTemplate({ show: false, nestedContent: 'oh hai' }));
-  assert(!container.querySelector('#conditional'));
-  render(container, getTemplate({ show: true, nestedContent: 'oh hai' }));
-  assert(container.querySelector('#conditional').textContent === 'oh hai');
-  render(container, getTemplate({ show: true, nestedContent: 'k bye' }));
-  assert(container.querySelector('#conditional').textContent === 'k bye');
-  container.remove();
-});
-
-it('html: renders attributes', () => {
-  const getTemplate = ({ attr }) => {
-    return html`<div id="target" attr="${attr}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ attr: 'foo' }));
-  assert(container.querySelector('#target').getAttribute('attr') === 'foo');
-  render(container, getTemplate({ attr: 'bar' }));
-  assert(container.querySelector('#target').getAttribute('attr') === 'bar');
-  container.remove();
-});
-
-it('html: renders boolean attributes', () => {
-  const getTemplate = ({ attr }) => {
-    return html`<div id="target" ?attr="${attr}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ attr: 'foo' }));
-  assert(container.querySelector('#target').getAttribute('attr') === '');
-  render(container, getTemplate({ attr: '' }));
-  assert(container.querySelector('#target').getAttribute('attr') === null);
-  render(container, getTemplate({ attr: 'bar' }));
-  assert(container.querySelector('#target').getAttribute('attr') === '');
-  render(container, getTemplate({ attr: undefined }));
-  assert(container.querySelector('#target').getAttribute('attr') === null);
-  render(container, getTemplate({ attr: 'baz' }));
-  assert(container.querySelector('#target').getAttribute('attr') === '');
-  render(container, getTemplate({ attr: false }));
-  assert(container.querySelector('#target').getAttribute('attr') === null);
-  render(container, getTemplate({ attr: true }));
-  assert(container.querySelector('#target').getAttribute('attr') === '');
-  container.remove();
-});
-
-it('html: renders properties', () => {
-  const getTemplate = ({ prop }) => {
-    return html`<div id="target" .prop="${prop}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ prop: 'foo' }));
-  assert(container.querySelector('#target').prop === 'foo');
-  render(container, getTemplate({ prop: 'bar' }));
-  assert(container.querySelector('#target').prop === 'bar');
-  container.remove();
-});
-
-it('html: maintains DOM nodes', () => {
-  const getTemplate = ({ content }) => {
-    return html`<div>${content}</div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ content: 'foo' }));
-  container.querySelector('div').classList.add('state');
-  assert(container.querySelector('div').textContent === 'foo');
-  assert(container.querySelector('div').classList.contains('state'));
-  render(container, getTemplate({ content: 'bar' }));
-  assert(container.querySelector('div').textContent === 'bar');
-  assert(container.querySelector('div').classList.contains('state'));
-  container.remove();
-});
-
-it('html: renders lists', () => {
-  const getTemplate = ({ items }) => {
-    return html`
-      <div id="target">
-        ${items.map(item => html`<div>${item}</div>`)}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ items: ['foo', 'bar', 'baz'] }));
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(container.querySelector('#target').children[0].textContent === 'foo');
-  assert(container.querySelector('#target').children[1].textContent === 'bar');
-  assert(container.querySelector('#target').children[2].textContent === 'baz');
-  container.remove();
-});
-
-it('html: renders lists with multiple elements', () => {
-  const getTemplate = ({ items }) => {
-    return html`
-      <div id="target">
-        ${items.map(item => html`<div>${item}-</div><div>${item}</div>`)}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ items: ['foo', 'bar', 'baz'] }));
-  assert(container.querySelector('#target').childElementCount === 6);
-  assert(container.querySelector('#target').children[0].textContent === 'foo-');
-  assert(container.querySelector('#target').children[1].textContent === 'foo');
-  assert(container.querySelector('#target').children[2].textContent === 'bar-');
-  assert(container.querySelector('#target').children[3].textContent === 'bar');
-  assert(container.querySelector('#target').children[4].textContent === 'baz-');
-  assert(container.querySelector('#target').children[5].textContent === 'baz');
-  container.remove();
-});
-
-it('html: renders lists with changing templates', () => {
-  const getTemplate = ({ items }) => {
-    return html`
-      <div id="target">
-        ${items.map(item => item ? html`<div class="true"></div>` : html`<div class="false"></div>`)}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ items: [true, true, true] }));
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(container.querySelector('#target').children[0].classList.contains('true'));
-  assert(container.querySelector('#target').children[1].classList.contains('true'));
-  assert(container.querySelector('#target').children[2].classList.contains('true'));
-  render(container, getTemplate({ items: [true, false, true] }));
-  assert(container.querySelector('#target').children[0].classList.contains('true'));
-  assert(container.querySelector('#target').children[1].classList.contains('false'));
-  assert(container.querySelector('#target').children[2].classList.contains('true'));
-  container.remove();
-});
-
-it('html: renders lists with changing length', () => {
-  const getTemplate = ({ items }) => {
-    return html`
-      <div id="target">
-        ${items.map(() => html`<div class="item"></div>`)}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ items: [1, 2, 3] }));
-  assert(container.querySelector('#target').childElementCount === 3);
-  render(container, getTemplate({ items: [1, 2, 3, 4, 5] }));
-  assert(container.querySelector('#target').childElementCount === 5);
-  render(container, getTemplate({ items: [1, 2] }));
-  assert(container.querySelector('#target').childElementCount === 2);
-  container.remove();
-});
-
-it('html: renders multiple templates', () => {
-  const getTemplate = ({ content }) => {
-    if (content) {
-      return html`<div id="content">${content}</div>`;
-    } else {
-      return html`<div id="empty"></div>`;
-    }
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ content: 'oh hai' }));
-  assert(!!container.querySelector('#content'));
-  assert(!container.querySelector('#empty'));
-  render(container, getTemplate({ content: '' }));
-  assert(!container.querySelector('#content'));
-  assert(!!container.querySelector('#empty'));
-  container.remove();
-});
-
-it('html: renders multiple templates (as content)', () => {
-  const getTemplate = ({ content }) => {
-    return html`
-      <div id="target">
-        ${content ? html`<div id="content">${content}</div>` : html`<div id="empty"></div>`}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ content: 'oh hai' }));
-  assert(!!container.querySelector('#content'));
-  assert(!container.querySelector('#empty'));
-  render(container, getTemplate({ content: '' }));
-  assert(!container.querySelector('#content'));
-  assert(!!container.querySelector('#empty'));
-  container.remove();
-});
-
-it('html: renders elements with "/" characters in attributes', () => {
-  // Note the "/" character.
-  const getTemplate = ({ width, height }) => {
-    return html`\
-      <svg
-        id="svg"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        width="${ifDefined(width)}"
-        height="${ifDefined(height)}">
-        <circle id="circle" r="${width / 2}" cx="${width / 2}" cy="${height / 2}"></circle>
-      </svg>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  const width = 24;
-  const height = 24;
-  render(container, getTemplate({ width, height }));
-  const svgBox = container.querySelector('#svg').getBoundingClientRect();
-  assert(svgBox.width === width);
-  assert(svgBox.height === height);
-  const circleBox = container.querySelector('#circle').getBoundingClientRect();
-  assert(circleBox.width === width);
-  assert(circleBox.height === height);
-  container.remove();
-});
-
-// TODO: trying to find escaped values in strings is possible via a regex, but
-//  making that performant is nuanced. I.e., it's easy to cause catastrophic
-//  backtracking.
-todo('html: renders elements with "<" or ">" characters in attributes', () => {
-  // Note the "/", "<", and ">" characters.
-  const getTemplate = ({ width, height }) => {
-    return html`\
-      <svg
-        id="svg"
-        class="<><></></>"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        width="${ifDefined(width)}"
-        height="${ifDefined(height)}">
-        <circle id="circle" r="${width / 2}" cx="${width / 2}" cy="${height / 2}"></circle>
-      </svg>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  const width = 24;
-  const height = 24;
-  render(container, getTemplate({ width, height }));
-  const svgBox = container.querySelector('#svg').getBoundingClientRect();
-  assert(svgBox.width === width);
-  assert(svgBox.height === height);
-  const circleBox = container.querySelector('#circle').getBoundingClientRect();
-  assert(circleBox.width === width);
-  assert(circleBox.height === height);
-  container.remove();
-});
-
-it('html: self-closing tags work', () => {
-  const getTemplate = ({ type }) => {
-    return html`<input type="${nullish(type)}"/>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ type: null }));
-  assert(container.querySelector('input').type === 'text');
-  render(container, getTemplate({ type: 'checkbox' }));
-  assert(container.querySelector('input').type === 'checkbox');
-  container.remove();
-});
-
-it('html: textarea element content', () => {
-  const getTemplate = ({ defaultValue }) => {
-    return html`<textarea>${defaultValue}</textarea>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ defaultValue: 'foo' }));
-  assert(container.querySelector('textarea').value === 'foo');
-  container.remove();
-});
-
-// This is mainly for backwards compat, "nullish" is likely a better match.
-it('html: updaters: ifDefined', () => {
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" maybe="${ifDefined(maybe)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ maybe: 'yes' }));
-  assert(container.querySelector('#target').getAttribute('maybe') === 'yes');
-  render(container, getTemplate({ maybe: undefined }));
-  assert(container.querySelector('#target').getAttribute('maybe') === null);
-  render(container, getTemplate({ maybe: false }));
-  assert(container.querySelector('#target').getAttribute('maybe') === 'false');
-
-  // This is correct, but perhaps unexpected.
-  render(container, getTemplate({ maybe: null }));
-  assert(container.querySelector('#target').getAttribute('maybe') === 'null');
-  container.remove();
-});
-
-it('html: updaters: nullish', () => {
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" maybe="${nullish(maybe)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ maybe: 'yes' }));
-  assert(container.querySelector('#target').getAttribute('maybe') === 'yes');
-  render(container, getTemplate({ maybe: undefined }));
-  assert(container.querySelector('#target').getAttribute('maybe') === null);
-  render(container, getTemplate({ maybe: false }));
-  assert(container.querySelector('#target').getAttribute('maybe') === 'false');
-  render(container, getTemplate({ maybe: null }));
-  assert(container.querySelector('#target').getAttribute('maybe') === null);
-  container.remove();
-});
-
-it('html: updaters: live', () => {
-  const getTemplate = ({ alive, dead }) => {
-    return html`<div id="target" .alive="${live(alive)}" .dead="${dead}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ alive: 'lively', dead: 'deadly' }));
-  assert(container.querySelector('#target').alive === 'lively');
-  assert(container.querySelector('#target').dead === 'deadly');
-  container.querySelector('#target').alive = 'changed';
-  container.querySelector('#target').dead = 'changed';
-  assert(container.querySelector('#target').alive === 'changed');
-  assert(container.querySelector('#target').dead === 'changed');
-  render(container, getTemplate({ alive: 'lively', dead: 'deadly' }));
-  assert(container.querySelector('#target').alive === 'lively');
-  assert(container.querySelector('#target').dead === 'changed');
-  container.remove();
-});
-
-it('html: updaters: unsafeHTML', () => {
-  const getTemplate = ({ content }) => {
-    return html`<div id="target">${unsafeHTML(content)}</div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ content: '<div id="injected">oh hai</div>' }));
-  assert(!!container.querySelector('#injected'));
-  render(container, getTemplate({ content: '<div id="booster">oh hai, again</div>' }));
-  assert(!!container.querySelector('#booster'));
-  container.remove();
-});
-
-// This is mainly for backwards compat, TBD if we deprecate or not.
-it('html: updaters: repeat works when called with all arguments', () => {
-  const getTemplate = ({ items }) => {
-    return html`
-      <div id="target">
-        ${repeat(items, item => item.id, item => {
-          return html`<div id="${item.id}" class="item">${item.id}</div>`;
-        })}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
-  const foo = container.querySelector('#foo');
-  const bar = container.querySelector('#bar');
-  const baz = container.querySelector('#baz');
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(!!foo);
-  assert(!!bar);
-  assert(!!baz);
-  assert(container.querySelector('#target').children[0] === foo);
-  assert(container.querySelector('#target').children[1] === bar);
-  assert(container.querySelector('#target').children[2] === baz);
-  render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(container.querySelector('#target').children[0] === foo);
-  assert(container.querySelector('#target').children[1] === bar);
-  assert(container.querySelector('#target').children[2] === baz);
-  render(container, getTemplate({ items: [{ id: 'baz' }, { id: 'foo' }, { id: 'bar'}] }));
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(container.querySelector('#target').children[0] === baz);
-  assert(container.querySelector('#target').children[1] === foo);
-  assert(container.querySelector('#target').children[2] === bar);
-  render(container, getTemplate({ items: [{ id: 'bar'}, { id: 'baz' }, { id: 'foo' }] }));
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(container.querySelector('#target').children[0] === bar);
-  assert(container.querySelector('#target').children[1] === baz);
-  assert(container.querySelector('#target').children[2] === foo);
-  render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(container.querySelector('#target').children[0] === foo);
-  assert(container.querySelector('#target').children[1] === bar);
-  assert(container.querySelector('#target').children[2] === baz);
-  render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}] }));
-  assert(container.querySelector('#target').childElementCount === 2);
-  assert(container.querySelector('#target').children[0] === foo);
-  assert(container.querySelector('#target').children[1] === bar);
-  render(container, getTemplate({ items: [{ id: 'foo' }] }));
-  assert(container.querySelector('#target').childElementCount === 1);
-  assert(container.querySelector('#target').children[0] === foo);
-  render(container, getTemplate({ items: [] }));
-  assert(container.querySelector('#target').childElementCount === 0);
-  render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(container.querySelector('#target').children[0] !== foo);
-  assert(container.querySelector('#target').children[1] !== bar);
-  assert(container.querySelector('#target').children[2] !== baz);
-  container.remove();
-});
-
-it('html: updaters: repeat works when called with omitted lookup', () => {
-  const getTemplate = ({ items }) => {
-    return html`
-      <div id="target">
-        ${repeat(items, item => {
-          return html`<div id="${item.id}" class="item">${item.id}</div>`;
-        })}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
-  const foo = container.querySelector('#foo');
-  const bar = container.querySelector('#bar');
-  const baz = container.querySelector('#baz');
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(!!foo);
-  assert(!!bar);
-  assert(!!baz);
-  assert(container.querySelector('#target').children[0] === foo);
-  assert(container.querySelector('#target').children[1] === bar);
-  assert(container.querySelector('#target').children[2] === baz);
-  render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(container.querySelector('#target').children[0] === foo);
-  assert(container.querySelector('#target').children[1] === bar);
-  assert(container.querySelector('#target').children[2] === baz);
-
-  // Because "lookup" is omitted, we don't expect DOM nodes to remain after a shift.
-  render(container, getTemplate({ items: [{ id: 'baz' }, { id: 'foo' }, { id: 'bar'}] }));
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(container.querySelector('#target').children[0] !== baz);
-  assert(container.querySelector('#target').children[1] !== foo);
-  assert(container.querySelector('#target').children[2] !== bar);
-  container.remove();
-});
-
-it('html: updaters: map', () => {
-  const getTemplate = ({ items }) => {
-    return html`
-      <div id="target">
-        ${map(items, item => item.id, item => {
-          return html`<div id="${item.id}" class="item">${item.id}</div>`;
-        })}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
-  const foo = container.querySelector('#foo');
-  const bar = container.querySelector('#bar');
-  const baz = container.querySelector('#baz');
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(!!foo);
-  assert(!!bar);
-  assert(!!baz);
-  assert(container.querySelector('#target').children[0] === foo);
-  assert(container.querySelector('#target').children[1] === bar);
-  assert(container.querySelector('#target').children[2] === baz);
-  render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(container.querySelector('#target').children[0] === foo);
-  assert(container.querySelector('#target').children[1] === bar);
-  assert(container.querySelector('#target').children[2] === baz);
-  render(container, getTemplate({ items: [{ id: 'baz' }, { id: 'foo' }, { id: 'bar'}] }));
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(container.querySelector('#target').children[0] === baz);
-  assert(container.querySelector('#target').children[1] === foo);
-  assert(container.querySelector('#target').children[2] === bar);
-  render(container, getTemplate({ items: [{ id: 'bar'}, { id: 'baz' }, { id: 'foo' }] }));
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(container.querySelector('#target').children[0] === bar);
-  assert(container.querySelector('#target').children[1] === baz);
-  assert(container.querySelector('#target').children[2] === foo);
-  render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(container.querySelector('#target').children[0] === foo);
-  assert(container.querySelector('#target').children[1] === bar);
-  assert(container.querySelector('#target').children[2] === baz);
-  render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}] }));
-  assert(container.querySelector('#target').childElementCount === 2);
-  assert(container.querySelector('#target').children[0] === foo);
-  assert(container.querySelector('#target').children[1] === bar);
-  render(container, getTemplate({ items: [{ id: 'foo' }] }));
-  assert(container.querySelector('#target').childElementCount === 1);
-  assert(container.querySelector('#target').children[0] === foo);
-  render(container, getTemplate({ items: [] }));
-  assert(container.querySelector('#target').childElementCount === 0);
-  render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
-  assert(container.querySelector('#target').childElementCount === 3);
-  assert(container.querySelector('#target').children[0] !== foo);
-  assert(container.querySelector('#target').children[1] !== bar);
-  assert(container.querySelector('#target').children[2] !== baz);
-  container.remove();
-});
-
-it('html: updaters: map: template changes', () => {
-  const getTemplate = ({ items }) => {
-    return html`
-      <div id="target">
-        ${map(items, item => item.id, item => {
-          return item.show ? html`<div id="${item.id}" class="item">${item.id}</div>` : html`<div id="${item.id}" class="item"></div>`;
-        })}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ items: [{ id: 'foo', show: true }] }));
-  const foo = container.querySelector('#foo');
-  assert(container.querySelector('#target').childElementCount === 1);
-  assert(!!foo);
-  assert(container.querySelector('#target').children[0] === foo);
-  render(container, getTemplate({ items: [{ id: 'foo', show: false }] }));
-  assert(container.querySelector('#target').childElementCount === 1);
-  assert(!!container.querySelector('#foo'));
-  assert(container.querySelector('#target').children[0] !== foo);
-  container.remove();
-});
-
-it('svg: renders a basic string', () => {
-  const getTemplate = ({ r, cx, cy }) => {
-    return svg`<circle id="target" r="${r}" cx="${cx}" cy="${cy}"/>`;
-  };
-  const container = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-  container.setAttribute('viewBox', '0 0 100 100');
-  container.setAttribute('style', 'height: 100px; width: 100px;');
-  document.body.append(container);
-  render(container, getTemplate({ r: 10, cx: 50, cy: 50 }));
-  assert(container.querySelector('#target').getBoundingClientRect().width === 20);
-  assert(container.querySelector('#target').getBoundingClientRect().height === 20);
-  render(container, getTemplate({ r: 5, cx: 50, cy: 50 }));
-  assert(container.querySelector('#target').getBoundingClientRect().width === 10);
-  assert(container.querySelector('#target').getBoundingClientRect().height === 10);
-  container.remove();
-});
-
-it('svg: renders lists', () => {
-  const getTemplate = ({ items }) => {
-    return html`
-      <svg id="target"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 10 100"
-        style="width: 10px; height: 100px;">
-        ${items.map((item, index) => {
-          return svg`<circle class="dot" r="${item.r}" cx="5" cy="${10 * (index + 1)}"></circle>`;
-        })}
-      </svg>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ items: [{ r: 1 }, { r: 2 }, { r: 3 }, { r: 4 }, { r: 5 }] }));
-  assert(container.querySelector('#target').childElementCount === 5);
-  assert(container.querySelector('#target').children[0].getBoundingClientRect().height = 2);
-  assert(container.querySelector('#target').children[1].getBoundingClientRect().height = 4);
-  assert(container.querySelector('#target').children[2].getBoundingClientRect().height = 6);
-  assert(container.querySelector('#target').children[3].getBoundingClientRect().height = 8);
-  assert(container.querySelector('#target').children[4].getBoundingClientRect().height = 10);
-  container.remove();
-});
-
-it('svg: updaters: unsafeSVG', () => {
-  const getTemplate = ({ content }) => {
-    return html`
-      <svg
-        id="target"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 100 100"
-        style="width: 100px; height: 100px;">
-        ${unsafeSVG(content)}
-      </svg>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ content: '<circle id="injected" r="10" cx="50" cy="50"></circle>' }));
-  assert(!!container.querySelector('#injected'));
-  assert(container.querySelector('#injected').getBoundingClientRect().height = 20);
-  assert(container.querySelector('#injected').getBoundingClientRect().width = 20);
-  render(container, getTemplate({ content: '<circle id="injected" r="5" cx="50" cy="50"></circle>' }));
-  assert(!!container.querySelector('#injected'));
-  assert(container.querySelector('#injected').getBoundingClientRect().height = 10);
-  assert(container.querySelector('#injected').getBoundingClientRect().width = 10);
-  container.remove();
-});
-
-it('render errors: ifDefined: throws if used on a "boolean-attribute"', () => {
-  const expected = 'The ifDefined update must be used on an attribute, not on a boolean-attribute.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" ?maybe="${ifDefined(maybe)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: ifDefined: throws if used on a "property"', () => {
-  const expected = 'The ifDefined update must be used on an attribute, not on a property.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" .maybe="${ifDefined(maybe)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: ifDefined: throws if used with "content"', () => {
-  const expected = 'The ifDefined update must be used on an attribute, not on content.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target">${ifDefined(maybe)}</div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: ifDefined: throws if used with "text-content"', () => {
-  const expected = 'The ifDefined update must be used on an attribute, not on text-content.';
-  const getTemplate = ({ maybe }) => {
-    return html`<textarea id="target">${ifDefined(maybe)}</textarea>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: nullish: throws if used on a "boolean-attribute"', () => {
-  const expected = 'The nullish update must be used on an attribute, not on a boolean-attribute.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" ?maybe="${nullish(maybe)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: nullish: throws if used on a "property"', () => {
-  const expected = 'The nullish update must be used on an attribute, not on a property.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" .maybe="${nullish(maybe)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: nullish: throws if used with "content"', () => {
-  const expected = 'The nullish update must be used on an attribute, not on content.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target">${nullish(maybe)}</div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: nullish: throws if used with "text-content"', () => {
-  const expected = 'The nullish update must be used on an attribute, not on text-content.';
-  const getTemplate = ({ maybe }) => {
-    return html`<textarea id="target">${nullish(maybe)}</textarea>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: live: throws if used on an "attribute"', () => {
-  const expected = 'The live update must be used on a property, not on an attribute.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" maybe="${live(maybe)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: live: throws if used on a "boolean-attribute"', () => {
-  const expected = 'The live update must be used on a property, not on a boolean-attribute.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" ?maybe="${live(maybe)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: live: throws if used with "content"', () => {
-  const expected = 'The live update must be used on a property, not on content.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target">${live(maybe)}</div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: live: throws if used with "text-content"', () => {
-  const expected = 'The live update must be used on a property, not on text-content.';
-  const getTemplate = ({ maybe }) => {
-    return html`<textarea id="target">${live(maybe)}</textarea>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: unsafeHTML: throws if used on an "attribute"', () => {
-  const expected = 'The unsafeHTML update must be used on content, not on an attribute.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" maybe="${unsafeHTML(maybe)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: unsafeHTML: throws if used on a "boolean-attribute"', () => {
-  const expected = 'The unsafeHTML update must be used on content, not on a boolean-attribute.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" ?maybe="${unsafeHTML(maybe)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: unsafeHTML: throws if used with a "property"', () => {
-  const expected = 'The unsafeHTML update must be used on content, not on a property.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" .maybe="${unsafeHTML(maybe)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: unsafeHTML: throws if used with "text-content"', () => {
-  const expected = 'The unsafeHTML update must be used on content, not on text-content.';
-  const getTemplate = ({ maybe }) => {
-    return html`<textarea id="target">${unsafeHTML(maybe)}</textarea>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: unsafeSVG: throws if used on an "attribute"', () => {
-  const expected = 'The unsafeSVG update must be used on content, not on an attribute.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" maybe="${unsafeSVG(maybe)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: unsafeSVG: throws if used on a "boolean-attribute"', () => {
-  const expected = 'The unsafeSVG update must be used on content, not on a boolean-attribute.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" ?maybe="${unsafeSVG(maybe)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: unsafeSVG: throws if used with a "property"', () => {
-  const expected = 'The unsafeSVG update must be used on content, not on a property.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" .maybe="${unsafeSVG(maybe)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: unsafeSVG: throws if used with "text-content"', () => {
-  const expected = 'The unsafeSVG update must be used on content, not on text-content.';
-  const getTemplate = ({ maybe }) => {
-    return html`<textarea id="target">${unsafeSVG(maybe)}</textarea>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: map: throws if identify is not a function', () => {
-  const expected = 'Unexpected map identify "undefined" provided, expected a function.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" maybe="${map(maybe)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: map: throws if callback is not a function', () => {
-  const expected = 'Unexpected map callback "undefined" provided, expected a function.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" maybe="${map(maybe, () => {})}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: map: throws if used on an "attribute"', () => {
-  const expected = 'The map update must be used on content, not on an attribute.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" maybe="${map(maybe, () => {}, () => {})}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: map: throws if used on a "boolean-attribute"', () => {
-  const expected = 'The map update must be used on content, not on a boolean-attribute.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" ?maybe="${map(maybe, () => {}, () => {})}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: map: throws if used with a "property"', () => {
-  const expected = 'The map update must be used on content, not on a property.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" .maybe="${map(maybe, () => {}, () => {})}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: map: throws if used with "text-content"', () => {
-  const expected = 'The map update must be used on content, not on text-content.';
-  const getTemplate = ({ maybe }) => {
-    return html`<textarea id="target">${map(maybe, () => {}, () => {})}</textarea>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: repeat: throws if callback is not a function (1)', () => {
-  const expected = 'Unexpected repeat identify "undefined" provided, expected a function.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" maybe="${repeat(maybe)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: repeat: throws if callback is not a function (2)', () => {
-  const expected = 'Unexpected repeat callback "5" provided, expected a function.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" maybe="${repeat(maybe, 5)}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: repeat: throws if used on an "attribute"', () => {
-  const expected = 'The repeat update must be used on content, not on an attribute.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" maybe="${repeat(maybe, () => {})}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: repeat: throws if used on a "boolean-attribute"', () => {
-  const expected = 'The repeat update must be used on content, not on a boolean-attribute.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" ?maybe="${repeat(maybe, () => {})}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: repeat: throws if used with a "property"', () => {
-  const expected = 'The repeat update must be used on content, not on a property.';
-  const getTemplate = ({ maybe }) => {
-    return html`<div id="target" .maybe="${repeat(maybe, () => {})}"></div>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: repeat: throws if used with "text-content"', () => {
-  const expected = 'The repeat update must be used on content, not on text-content.';
-  const getTemplate = ({ maybe }) => {
-    return html`<textarea id="target">${repeat(maybe, () => {})}</textarea>`;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let actual;
-  try {
-    render(container, getTemplate({ maybe: 'yes' }));
-  } catch (error) {
-    actual = error.message;
-  }
-  assert(!!actual, 'No error was thrown.');
-  assert(actual === expected, actual);
-  container.remove();
-});
-
-it('render errors: map: throws for non-array value', () => {
-  const getTemplate = ({ array }) => {
-    return html`
-      <div id="target">
-        ${map(array, () => {}, () => html``)}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let error;
-  try {
-    render(container, getTemplate({ array: 5 }));
-  } catch (e) {
-    error = e;
-  }
-  assert(error?.message === 'Unexpected map value "5".', error?.message);
-  container.remove();
-});
-
-it('render errors: map: throws for non-template callback value', () => {
-  const getTemplate = ({ array }) => {
-    return html`
-      <div id="target">
-        ${map(array, item => item.id, item => item.value ? html`<div>${item.value}</div>` : null)}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let error;
-  try {
-    render(container, getTemplate({ array: [{ id: 'foo', value: null }] }));
-  } catch (e) {
-    error = e;
-  }
-  assert(error?.message === 'Unexpected map value "null" provided by callback.', error?.message);
-  container.remove();
-});
-
-it('render errors: map: throws for non-template callback value (on re-render)', () => {
-  const getTemplate = ({ array }) => {
-    return html`
-      <div id="target">
-        ${map(array, item => item.id, item => item.value ? html`<div>${item.value}</div>` : null)}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ array: [{ id: 'foo', value: 'oh hai' }] }));
-  let error;
-  try {
-    render(container, getTemplate({ array: [{ id: 'foo', value: null }] }));
-  } catch (e) {
-    error = e;
-  }
-  assert(error?.message === 'Unexpected map value "null" provided by callback.', error?.message);
-  container.remove();
-});
-
-it('render errors: repeat: throws for non-array value', () => {
-  const getTemplate = ({ array }) => {
-    return html`
-      <div id="target">
-        ${repeat(array, () => {}, () => html``)}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let error;
-  try {
-    render(container, getTemplate({ array: 5 }));
-  } catch (e) {
-    error = e;
-  }
-  assert(error?.message === 'Unexpected repeat value "5".', error?.message);
-  container.remove();
-});
-
-it('render errors: repeat: throws for non-template callback value', () => {
-  const getTemplate = ({ array }) => {
-    return html`
-      <div id="target">
-        ${repeat(array, item => item.id, item => item.value ? html`<div>${item.value}</div>` : null)}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let error;
-  try {
-    render(container, getTemplate({ array: [{ id: 'foo', value: null }] }));
-  } catch (e) {
-    error = e;
-  }
-  assert(error?.message === 'Unexpected repeat value "null" provided by callback.', error?.message);
-  container.remove();
-});
-
-it('render errors: repeat: throws for non-template callback value (on re-render)', () => {
-  const getTemplate = ({ array }) => {
-    return html`
-      <div id="target">
-        ${repeat(array, item => item.id, item => item.value ? html`<div>${item.value}</div>` : null)}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ array: [{ id: 'foo', value: 'oh hai' }] }));
-  let error;
-  try {
-    render(container, getTemplate({ array: [{ id: 'foo', value: null }] }));
-  } catch (e) {
-    error = e;
-  }
-  assert(error?.message === 'Unexpected repeat value "null" provided by callback.', error?.message);
-  container.remove();
-});
-
-it('render errors: unsafeHTML: throws for non-string value', () => {
-  const getTemplate = ({ content }) => {
-    return html`
-      <div id="target">
-        ${unsafeHTML(content)}
-      </div>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let error;
-  try {
-    render(container, getTemplate({ content: null }));
-  } catch (e) {
-    error = e;
-  }
-  assert(error?.message === 'Unexpected unsafeHTML value "null".', error?.message);
-  container.remove();
-});
-
-it('render errors: unsafeSVG: throws for non-string value', () => {
-  const getTemplate = ({ content }) => {
-    return html`
-      <svg id="target" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-        ${unsafeSVG(content)}
-      </svg>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let error;
-  try {
-    render(container, getTemplate({ content: null }));
-  } catch (e) {
-    error = e;
-  }
-  assert(error?.message === 'Unexpected unsafeSVG value "null".', error?.message);
-  container.remove();
-});
-
-it('render errors: template array: throws for non-template value', () => {
-  const getTemplate = ({ items }) => {
-    return html`
-      <svg id="target" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-        ${items.map(item => item ? html`<div>${item}</div>` : null)}
-      </svg>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  let error;
-  try {
-    render(container, getTemplate({ items: [null] }));
-  } catch (e) {
-    error = e;
-  }
-  assert(error?.message === 'Unexpected array value "null" provided by callback.', error?.message);
-  container.remove();
-});
-
-it('render errors: template array (on re-render): throws for non-template value', () => {
-  const getTemplate = ({ items }) => {
-    return html`
-      <svg id="target" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-        ${items.map(item => item ? html`<div>${item}</div>` : null)}
-      </svg>
-    `;
-  };
-  const container = document.createElement('div');
-  document.body.append(container);
-  render(container, getTemplate({ items: ['foo'] }));
-  let error;
-  try {
-    render(container, getTemplate({ items: [null] }));
-  } catch (e) {
-    error = e;
-  }
-  assert(error?.message === 'Unexpected array value "null" provided by callback.', error?.message);
-  container.remove();
-});
-
-const removedInterfaceNames = [
-  'asyncAppend', 'asyncReplace', 'cache', 'classMap', 'directive', 'guard',
-  'styleMap', 'templateContent', 'until',
-];
-for (const name of removedInterfaceNames) {
-  it(`interface migration errors: "${name}" no longer exists.`, () => {
-    const expected = `Removed "${name}" from default templating engine interface. Import and plug-in "lit-html" as your element's templating engine if you want this functionality.`;
-    let actual;
-    try {
-      XElement.templateEngine[name]();
-    } catch (error) {
-      actual = error.message;
-    }
-    assert(!!actual, 'No error was thrown.');
-    assert(actual === expected, actual);
+describe('html rendering', () => {
+  it('renders basic string', () => {
+    const getTemplate = () => {
+      return html`<div id="target">No interpolation.</div>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate());
+    assert(container.querySelector('#target').textContent === 'No interpolation.');
+    container.remove();
   });
-}
+
+  it('refuses to interpolate within a style tag', () => {
+    const getTemplate = ({ color }) => {
+      return html`
+        <style id="target">
+          #target {
+            background-color: ${color};
+          }
+        </style>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ color: 'url(evil-url)' }));
+    const textContent = container.querySelector('#target').textContent;
+    assert(textContent === '/* x-element: Interpolation is not allowed here. */', textContent);
+    container.remove();
+  });
+
+  it('refuses to interpolate within a script tag', () => {
+    const getTemplate = ({ message }) => {
+      return html`
+        <script id="target">
+          console.log('${message}');
+        </script>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ message: '\' + prompt(\'evil\') + \'' }));
+    const textContent = container.querySelector('#target').textContent;
+    assert(textContent === '/* x-element: Interpolation is not allowed here. */', textContent);
+    container.remove();
+  });
+
+  it('renders interpolated content without parsing', () => {
+    const userContent = '<a href="https://evil.com">Click Me!</a>';
+    const getTemplate = () => {
+      return html`<div id="target">${userContent}</div>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate());
+    assert(container.querySelector('#target').textContent === userContent);
+    container.remove();
+  });
+
+  it('does not recognize single-quoted attributes', () => {
+    const getTemplate = () => {
+      return html`<div id="target" ignore-me='${'foo'}'>Gotta double-quote those.</div>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate());
+    assert(container.querySelector('#target').getAttribute('ignore-me') !== 'foo');
+    container.remove();
+  });
+
+  it('does not recognize single-quoted properties', () => {
+    const getTemplate = () => {
+      return html`<div id="target" .ignoreMe='${'foo'}'>Gotta double-quote those.</div>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate());
+    assert(container.querySelector('#target').ignoreMe !== 'foo');
+    container.remove();
+  });
+
+  it('refuses to reuse a template', () => {
+    const templateResultReference = html`<div id="target"></div>`;
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, templateResultReference);
+    assert(!!container.querySelector('#target'));
+    render(container, null);
+    assert(!container.querySelector('#target'));
+    let error;
+    try {
+      render(container, templateResultReference);
+    } catch (e) {
+      error = e;
+    }
+    assert(error?.message === 'Unexpected re-injection of template result.', error.message);
+    container.remove();
+  });
+
+  it('renders nullish templates', () => {
+    const getTemplate = () => {
+      return html`<div></div>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate());
+    assert(!!container.childNodes.length);
+    render(container, null);
+    assert(!container.childNodes.length);
+    render(container, getTemplate());
+    assert(!!container.childNodes.length);
+    render(container, undefined);
+    assert(!container.childNodes.length);
+    container.remove();
+  });
+
+  it('renders interpolated content', () => {
+    const getTemplate = ({ content }) => {
+      return html`<div id="target">${content}</div>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ content: 'Interpolated.' }));
+    assert(container.querySelector('#target').textContent === 'Interpolated.');
+    render(container, getTemplate({ content: 'Updated.' }));
+    assert(container.querySelector('#target').textContent === 'Updated.');
+    container.remove();
+  });
+
+  it('renders multiple, interpolated content', () => {
+    const getTemplate = ({ one, two }) => {
+      return html`
+        <div id="target">one: ${one} / two: ${two}</div>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ one: 'ONE', two: 'TWO' }));
+    assert(container.querySelector('#target').textContent === 'one: ONE / two: TWO');
+    container.remove();
+  });
+
+  it('renders nested content', () => {
+    const getTemplate = ({ show, nestedContent }) => {
+      return html`
+        <div id="target">
+          ${show ? html`<span id="conditional">${nestedContent}</span>` : null}
+        </div>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ show: true, nestedContent: 'oh hai' }));
+    assert(!!container.querySelector('#conditional'));
+    render(container, getTemplate({ show: false, nestedContent: 'oh hai' }));
+    assert(!container.querySelector('#conditional'));
+    render(container, getTemplate({ show: true, nestedContent: 'oh hai' }));
+    assert(container.querySelector('#conditional').textContent === 'oh hai');
+    render(container, getTemplate({ show: true, nestedContent: 'k bye' }));
+    assert(container.querySelector('#conditional').textContent === 'k bye');
+    container.remove();
+  });
+
+  it('renders attributes', () => {
+    const getTemplate = ({ attr }) => {
+      return html`<div id="target" attr="${attr}"></div>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ attr: 'foo' }));
+    assert(container.querySelector('#target').getAttribute('attr') === 'foo');
+    render(container, getTemplate({ attr: 'bar' }));
+    assert(container.querySelector('#target').getAttribute('attr') === 'bar');
+    container.remove();
+  });
+
+  it('renders boolean attributes', () => {
+    const getTemplate = ({ attr }) => {
+      return html`<div id="target" ?attr="${attr}"></div>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ attr: 'foo' }));
+    assert(container.querySelector('#target').getAttribute('attr') === '');
+    render(container, getTemplate({ attr: '' }));
+    assert(container.querySelector('#target').getAttribute('attr') === null);
+    render(container, getTemplate({ attr: 'bar' }));
+    assert(container.querySelector('#target').getAttribute('attr') === '');
+    render(container, getTemplate({ attr: undefined }));
+    assert(container.querySelector('#target').getAttribute('attr') === null);
+    render(container, getTemplate({ attr: 'baz' }));
+    assert(container.querySelector('#target').getAttribute('attr') === '');
+    render(container, getTemplate({ attr: false }));
+    assert(container.querySelector('#target').getAttribute('attr') === null);
+    render(container, getTemplate({ attr: true }));
+    assert(container.querySelector('#target').getAttribute('attr') === '');
+    container.remove();
+  });
+
+  it('renders properties', () => {
+    const getTemplate = ({ prop }) => {
+      return html`<div id="target" .prop="${prop}"></div>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ prop: 'foo' }));
+    assert(container.querySelector('#target').prop === 'foo');
+    render(container, getTemplate({ prop: 'bar' }));
+    assert(container.querySelector('#target').prop === 'bar');
+    container.remove();
+  });
+
+  it('maintains DOM nodes', () => {
+    const getTemplate = ({ content }) => {
+      return html`<div>${content}</div>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ content: 'foo' }));
+    container.querySelector('div').classList.add('state');
+    assert(container.querySelector('div').textContent === 'foo');
+    assert(container.querySelector('div').classList.contains('state'));
+    render(container, getTemplate({ content: 'bar' }));
+    assert(container.querySelector('div').textContent === 'bar');
+    assert(container.querySelector('div').classList.contains('state'));
+    container.remove();
+  });
+
+  it('renders lists', () => {
+    const getTemplate = ({ items }) => {
+      return html`
+        <div id="target">
+          ${items.map(item => html`<div>${item}</div>`)}
+        </div>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ items: ['foo', 'bar', 'baz'] }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#target').children[0].textContent === 'foo');
+    assert(container.querySelector('#target').children[1].textContent === 'bar');
+    assert(container.querySelector('#target').children[2].textContent === 'baz');
+    container.remove();
+  });
+
+  it('renders lists with multiple elements', () => {
+    const getTemplate = ({ items }) => {
+      return html`
+        <div id="target">
+          ${items.map(item => html`<div>${item}-</div><div>${item}</div>`)}
+        </div>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ items: ['foo', 'bar', 'baz'] }));
+    assert(container.querySelector('#target').childElementCount === 6);
+    assert(container.querySelector('#target').children[0].textContent === 'foo-');
+    assert(container.querySelector('#target').children[1].textContent === 'foo');
+    assert(container.querySelector('#target').children[2].textContent === 'bar-');
+    assert(container.querySelector('#target').children[3].textContent === 'bar');
+    assert(container.querySelector('#target').children[4].textContent === 'baz-');
+    assert(container.querySelector('#target').children[5].textContent === 'baz');
+    container.remove();
+  });
+
+  it('renders lists with changing templates', () => {
+    const getTemplate = ({ items }) => {
+      return html`
+        <div id="target">
+          ${items.map(item => item ? html`<div class="true"></div>` : html`<div class="false"></div>`)}
+        </div>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ items: [true, true, true] }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#target').children[0].classList.contains('true'));
+    assert(container.querySelector('#target').children[1].classList.contains('true'));
+    assert(container.querySelector('#target').children[2].classList.contains('true'));
+    render(container, getTemplate({ items: [true, false, true] }));
+    assert(container.querySelector('#target').children[0].classList.contains('true'));
+    assert(container.querySelector('#target').children[1].classList.contains('false'));
+    assert(container.querySelector('#target').children[2].classList.contains('true'));
+    container.remove();
+  });
+
+  it('renders lists with changing length', () => {
+    const getTemplate = ({ items }) => {
+      return html`
+        <div id="target">
+          ${items.map(() => html`<div class="item"></div>`)}
+        </div>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ items: [1, 2, 3] }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    render(container, getTemplate({ items: [1, 2, 3, 4, 5] }));
+    assert(container.querySelector('#target').childElementCount === 5);
+    render(container, getTemplate({ items: [1, 2] }));
+    assert(container.querySelector('#target').childElementCount === 2);
+    container.remove();
+  });
+
+  it('renders multiple templates', () => {
+    const getTemplate = ({ content }) => {
+      if (content) {
+        return html`<div id="content">${content}</div>`;
+      } else {
+        return html`<div id="empty"></div>`;
+      }
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ content: 'oh hai' }));
+    assert(!!container.querySelector('#content'));
+    assert(!container.querySelector('#empty'));
+    render(container, getTemplate({ content: '' }));
+    assert(!container.querySelector('#content'));
+    assert(!!container.querySelector('#empty'));
+    container.remove();
+  });
+
+  it('renders multiple templates (as content)', () => {
+    const getTemplate = ({ content }) => {
+      return html`
+        <div id="target">
+          ${content ? html`<div id="content">${content}</div>` : html`<div id="empty"></div>`}
+        </div>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ content: 'oh hai' }));
+    assert(!!container.querySelector('#content'));
+    assert(!container.querySelector('#empty'));
+    render(container, getTemplate({ content: '' }));
+    assert(!container.querySelector('#content'));
+    assert(!!container.querySelector('#empty'));
+    container.remove();
+  });
+
+  it('renders elements with "/" characters in attributes', () => {
+    // Note the "/" character.
+    const getTemplate = ({ width, height }) => {
+      return html`\
+        <svg
+          id="svg"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          width="${ifDefined(width)}"
+          height="${ifDefined(height)}">
+          <circle id="circle" r="${width / 2}" cx="${width / 2}" cy="${height / 2}"></circle>
+        </svg>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    const width = 24;
+    const height = 24;
+    render(container, getTemplate({ width, height }));
+    const svgBox = container.querySelector('#svg').getBoundingClientRect();
+    assert(svgBox.width === width);
+    assert(svgBox.height === height);
+    const circleBox = container.querySelector('#circle').getBoundingClientRect();
+    assert(circleBox.width === width);
+    assert(circleBox.height === height);
+    container.remove();
+  });
+
+  // TODO: trying to find escaped values in strings is possible via a regex, but
+  //  making that performant is nuanced. I.e., it's easy to cause catastrophic
+  //  backtracking.
+  it.todo('renders elements with "<" or ">" characters in attributes', () => {
+    // Note the "/", "<", and ">" characters.
+    const getTemplate = ({ width, height }) => {
+      return html`\
+        <svg
+          id="svg"
+          class="<><></></>"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          width="${ifDefined(width)}"
+          height="${ifDefined(height)}">
+          <circle id="circle" r="${width / 2}" cx="${width / 2}" cy="${height / 2}"></circle>
+        </svg>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    const width = 24;
+    const height = 24;
+    render(container, getTemplate({ width, height }));
+    const svgBox = container.querySelector('#svg').getBoundingClientRect();
+    assert(svgBox.width === width);
+    assert(svgBox.height === height);
+    const circleBox = container.querySelector('#circle').getBoundingClientRect();
+    assert(circleBox.width === width);
+    assert(circleBox.height === height);
+    container.remove();
+  });
+
+  it('self-closing tags work', () => {
+    const getTemplate = ({ type }) => {
+      return html`<input type="${nullish(type)}"/>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ type: null }));
+    assert(container.querySelector('input').type === 'text');
+    render(container, getTemplate({ type: 'checkbox' }));
+    assert(container.querySelector('input').type === 'checkbox');
+    container.remove();
+  });
+
+  it('textarea element content', () => {
+    const getTemplate = ({ defaultValue }) => {
+      return html`<textarea>${defaultValue}</textarea>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ defaultValue: 'foo' }));
+    assert(container.querySelector('textarea').value === 'foo');
+    container.remove();
+  });
+});
+
+describe('html updaters', () => {
+  // This is mainly for backwards compat, "nullish" is likely a better match.
+  it('ifDefined', () => {
+    const getTemplate = ({ maybe }) => {
+      return html`<div id="target" maybe="${ifDefined(maybe)}"></div>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ maybe: 'yes' }));
+    assert(container.querySelector('#target').getAttribute('maybe') === 'yes');
+    render(container, getTemplate({ maybe: undefined }));
+    assert(container.querySelector('#target').getAttribute('maybe') === null);
+    render(container, getTemplate({ maybe: false }));
+    assert(container.querySelector('#target').getAttribute('maybe') === 'false');
+
+    // This is correct, but perhaps unexpected.
+    render(container, getTemplate({ maybe: null }));
+    assert(container.querySelector('#target').getAttribute('maybe') === 'null');
+    container.remove();
+  });
+
+  it('nullish', () => {
+    const getTemplate = ({ maybe }) => {
+      return html`<div id="target" maybe="${nullish(maybe)}"></div>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ maybe: 'yes' }));
+    assert(container.querySelector('#target').getAttribute('maybe') === 'yes');
+    render(container, getTemplate({ maybe: undefined }));
+    assert(container.querySelector('#target').getAttribute('maybe') === null);
+    render(container, getTemplate({ maybe: false }));
+    assert(container.querySelector('#target').getAttribute('maybe') === 'false');
+    render(container, getTemplate({ maybe: null }));
+    assert(container.querySelector('#target').getAttribute('maybe') === null);
+    container.remove();
+  });
+
+  it('live', () => {
+    const getTemplate = ({ alive, dead }) => {
+      return html`<div id="target" .alive="${live(alive)}" .dead="${dead}"></div>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ alive: 'lively', dead: 'deadly' }));
+    assert(container.querySelector('#target').alive === 'lively');
+    assert(container.querySelector('#target').dead === 'deadly');
+    container.querySelector('#target').alive = 'changed';
+    container.querySelector('#target').dead = 'changed';
+    assert(container.querySelector('#target').alive === 'changed');
+    assert(container.querySelector('#target').dead === 'changed');
+    render(container, getTemplate({ alive: 'lively', dead: 'deadly' }));
+    assert(container.querySelector('#target').alive === 'lively');
+    assert(container.querySelector('#target').dead === 'changed');
+    container.remove();
+  });
+
+  it('unsafeHTML', () => {
+    const getTemplate = ({ content }) => {
+      return html`<div id="target">${unsafeHTML(content)}</div>`;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ content: '<div id="injected">oh hai</div>' }));
+    assert(!!container.querySelector('#injected'));
+    render(container, getTemplate({ content: '<div id="booster">oh hai, again</div>' }));
+    assert(!!container.querySelector('#booster'));
+    container.remove();
+  });
+
+  // This is mainly for backwards compat, TBD if we deprecate or not.
+  it('repeat works when called with all arguments', () => {
+    const getTemplate = ({ items }) => {
+      return html`
+        <div id="target">
+          ${repeat(items, item => item.id, item => {
+            return html`<div id="${item.id}" class="item">${item.id}</div>`;
+          })}
+        </div>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
+    const foo = container.querySelector('#foo');
+    const bar = container.querySelector('#bar');
+    const baz = container.querySelector('#baz');
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(!!foo);
+    assert(!!bar);
+    assert(!!baz);
+    assert(container.querySelector('#target').children[0] === foo);
+    assert(container.querySelector('#target').children[1] === bar);
+    assert(container.querySelector('#target').children[2] === baz);
+    render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#target').children[0] === foo);
+    assert(container.querySelector('#target').children[1] === bar);
+    assert(container.querySelector('#target').children[2] === baz);
+    render(container, getTemplate({ items: [{ id: 'baz' }, { id: 'foo' }, { id: 'bar'}] }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#target').children[0] === baz);
+    assert(container.querySelector('#target').children[1] === foo);
+    assert(container.querySelector('#target').children[2] === bar);
+    render(container, getTemplate({ items: [{ id: 'bar'}, { id: 'baz' }, { id: 'foo' }] }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#target').children[0] === bar);
+    assert(container.querySelector('#target').children[1] === baz);
+    assert(container.querySelector('#target').children[2] === foo);
+    render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#target').children[0] === foo);
+    assert(container.querySelector('#target').children[1] === bar);
+    assert(container.querySelector('#target').children[2] === baz);
+    render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}] }));
+    assert(container.querySelector('#target').childElementCount === 2);
+    assert(container.querySelector('#target').children[0] === foo);
+    assert(container.querySelector('#target').children[1] === bar);
+    render(container, getTemplate({ items: [{ id: 'foo' }] }));
+    assert(container.querySelector('#target').childElementCount === 1);
+    assert(container.querySelector('#target').children[0] === foo);
+    render(container, getTemplate({ items: [] }));
+    assert(container.querySelector('#target').childElementCount === 0);
+    render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#target').children[0] !== foo);
+    assert(container.querySelector('#target').children[1] !== bar);
+    assert(container.querySelector('#target').children[2] !== baz);
+    container.remove();
+  });
+
+  it('repeat works when called with omitted lookup', () => {
+    const getTemplate = ({ items }) => {
+      return html`
+        <div id="target">
+          ${repeat(items, item => {
+            return html`<div id="${item.id}" class="item">${item.id}</div>`;
+          })}
+        </div>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
+    const foo = container.querySelector('#foo');
+    const bar = container.querySelector('#bar');
+    const baz = container.querySelector('#baz');
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(!!foo);
+    assert(!!bar);
+    assert(!!baz);
+    assert(container.querySelector('#target').children[0] === foo);
+    assert(container.querySelector('#target').children[1] === bar);
+    assert(container.querySelector('#target').children[2] === baz);
+    render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#target').children[0] === foo);
+    assert(container.querySelector('#target').children[1] === bar);
+    assert(container.querySelector('#target').children[2] === baz);
+
+    // Because "lookup" is omitted, we don't expect DOM nodes to remain after a shift.
+    render(container, getTemplate({ items: [{ id: 'baz' }, { id: 'foo' }, { id: 'bar'}] }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#target').children[0] !== baz);
+    assert(container.querySelector('#target').children[1] !== foo);
+    assert(container.querySelector('#target').children[2] !== bar);
+    container.remove();
+  });
+
+  it('map', () => {
+    const getTemplate = ({ items }) => {
+      return html`
+        <div id="target">
+          ${map(items, item => item.id, item => {
+            return html`<div id="${item.id}" class="item">${item.id}</div>`;
+          })}
+        </div>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
+    const foo = container.querySelector('#foo');
+    const bar = container.querySelector('#bar');
+    const baz = container.querySelector('#baz');
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(!!foo);
+    assert(!!bar);
+    assert(!!baz);
+    assert(container.querySelector('#target').children[0] === foo);
+    assert(container.querySelector('#target').children[1] === bar);
+    assert(container.querySelector('#target').children[2] === baz);
+    render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#target').children[0] === foo);
+    assert(container.querySelector('#target').children[1] === bar);
+    assert(container.querySelector('#target').children[2] === baz);
+    render(container, getTemplate({ items: [{ id: 'baz' }, { id: 'foo' }, { id: 'bar'}] }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#target').children[0] === baz);
+    assert(container.querySelector('#target').children[1] === foo);
+    assert(container.querySelector('#target').children[2] === bar);
+    render(container, getTemplate({ items: [{ id: 'bar'}, { id: 'baz' }, { id: 'foo' }] }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#target').children[0] === bar);
+    assert(container.querySelector('#target').children[1] === baz);
+    assert(container.querySelector('#target').children[2] === foo);
+    render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#target').children[0] === foo);
+    assert(container.querySelector('#target').children[1] === bar);
+    assert(container.querySelector('#target').children[2] === baz);
+    render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}] }));
+    assert(container.querySelector('#target').childElementCount === 2);
+    assert(container.querySelector('#target').children[0] === foo);
+    assert(container.querySelector('#target').children[1] === bar);
+    render(container, getTemplate({ items: [{ id: 'foo' }] }));
+    assert(container.querySelector('#target').childElementCount === 1);
+    assert(container.querySelector('#target').children[0] === foo);
+    render(container, getTemplate({ items: [] }));
+    assert(container.querySelector('#target').childElementCount === 0);
+    render(container, getTemplate({ items: [{ id: 'foo' }, { id: 'bar'}, { id: 'baz' }] }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#target').children[0] !== foo);
+    assert(container.querySelector('#target').children[1] !== bar);
+    assert(container.querySelector('#target').children[2] !== baz);
+    container.remove();
+  });
+
+  it('map: template changes', () => {
+    const getTemplate = ({ items }) => {
+      return html`
+        <div id="target">
+          ${map(items, item => item.id, item => {
+            return item.show ? html`<div id="${item.id}" class="item">${item.id}</div>` : html`<div id="${item.id}" class="item"></div>`;
+          })}
+        </div>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ items: [{ id: 'foo', show: true }] }));
+    const foo = container.querySelector('#foo');
+    assert(container.querySelector('#target').childElementCount === 1);
+    assert(!!foo);
+    assert(container.querySelector('#target').children[0] === foo);
+    render(container, getTemplate({ items: [{ id: 'foo', show: false }] }));
+    assert(container.querySelector('#target').childElementCount === 1);
+    assert(!!container.querySelector('#foo'));
+    assert(container.querySelector('#target').children[0] !== foo);
+    container.remove();
+  });
+});
+
+describe('svg rendering', () => {
+  it('renders a basic string', () => {
+    const getTemplate = ({ r, cx, cy }) => {
+      return svg`<circle id="target" r="${r}" cx="${cx}" cy="${cy}"/>`;
+    };
+    const container = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    container.setAttribute('viewBox', '0 0 100 100');
+    container.setAttribute('style', 'height: 100px; width: 100px;');
+    document.body.append(container);
+    render(container, getTemplate({ r: 10, cx: 50, cy: 50 }));
+    assert(container.querySelector('#target').getBoundingClientRect().width === 20);
+    assert(container.querySelector('#target').getBoundingClientRect().height === 20);
+    render(container, getTemplate({ r: 5, cx: 50, cy: 50 }));
+    assert(container.querySelector('#target').getBoundingClientRect().width === 10);
+    assert(container.querySelector('#target').getBoundingClientRect().height === 10);
+    container.remove();
+  });
+
+  it('renders lists', () => {
+    const getTemplate = ({ items }) => {
+      return html`
+        <svg id="target"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 10 100"
+          style="width: 10px; height: 100px;">
+          ${items.map((item, index) => {
+            return svg`<circle class="dot" r="${item.r}" cx="5" cy="${10 * (index + 1)}"></circle>`;
+          })}
+        </svg>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ items: [{ r: 1 }, { r: 2 }, { r: 3 }, { r: 4 }, { r: 5 }] }));
+    assert(container.querySelector('#target').childElementCount === 5);
+    assert(container.querySelector('#target').children[0].getBoundingClientRect().height = 2);
+    assert(container.querySelector('#target').children[1].getBoundingClientRect().height = 4);
+    assert(container.querySelector('#target').children[2].getBoundingClientRect().height = 6);
+    assert(container.querySelector('#target').children[3].getBoundingClientRect().height = 8);
+    assert(container.querySelector('#target').children[4].getBoundingClientRect().height = 10);
+    container.remove();
+  });
+});
+
+describe('svg updaters', () => {
+  it('unsafeSVG', () => {
+    const getTemplate = ({ content }) => {
+      return html`
+        <svg
+          id="target"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 100 100"
+          style="width: 100px; height: 100px;">
+          ${unsafeSVG(content)}
+        </svg>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ content: '<circle id="injected" r="10" cx="50" cy="50"></circle>' }));
+    assert(!!container.querySelector('#injected'));
+    assert(container.querySelector('#injected').getBoundingClientRect().height = 20);
+    assert(container.querySelector('#injected').getBoundingClientRect().width = 20);
+    render(container, getTemplate({ content: '<circle id="injected" r="5" cx="50" cy="50"></circle>' }));
+    assert(!!container.querySelector('#injected'));
+    assert(container.querySelector('#injected').getBoundingClientRect().height = 10);
+    assert(container.querySelector('#injected').getBoundingClientRect().width = 10);
+    container.remove();
+  });
+});
+
+describe('rendering errors', () => {
+  describe('ifDefined', () => {
+    it('throws if used on a "boolean-attribute"', () => {
+      const expected = 'The ifDefined update must be used on an attribute, not on a boolean-attribute.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" ?maybe="${ifDefined(maybe)}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used on a "property"', () => {
+      const expected = 'The ifDefined update must be used on an attribute, not on a property.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" .maybe="${ifDefined(maybe)}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used with "content"', () => {
+      const expected = 'The ifDefined update must be used on an attribute, not on content.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target">${ifDefined(maybe)}</div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used with "text-content"', () => {
+      const expected = 'The ifDefined update must be used on an attribute, not on text-content.';
+      const getTemplate = ({ maybe }) => {
+        return html`<textarea id="target">${ifDefined(maybe)}</textarea>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+  });
+
+  describe('nullish', () => {
+    it('throws if used on a "boolean-attribute"', () => {
+      const expected = 'The nullish update must be used on an attribute, not on a boolean-attribute.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" ?maybe="${nullish(maybe)}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used on a "property"', () => {
+      const expected = 'The nullish update must be used on an attribute, not on a property.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" .maybe="${nullish(maybe)}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used with "content"', () => {
+      const expected = 'The nullish update must be used on an attribute, not on content.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target">${nullish(maybe)}</div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used with "text-content"', () => {
+      const expected = 'The nullish update must be used on an attribute, not on text-content.';
+      const getTemplate = ({ maybe }) => {
+        return html`<textarea id="target">${nullish(maybe)}</textarea>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+  });
+
+  describe('live', () => {
+    it('throws if used on an "attribute"', () => {
+      const expected = 'The live update must be used on a property, not on an attribute.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" maybe="${live(maybe)}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used on a "boolean-attribute"', () => {
+      const expected = 'The live update must be used on a property, not on a boolean-attribute.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" ?maybe="${live(maybe)}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used with "content"', () => {
+      const expected = 'The live update must be used on a property, not on content.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target">${live(maybe)}</div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used with "text-content"', () => {
+      const expected = 'The live update must be used on a property, not on text-content.';
+      const getTemplate = ({ maybe }) => {
+        return html`<textarea id="target">${live(maybe)}</textarea>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+  });
+
+  describe('unsafeHTML', () => {
+    it('throws if used on an "attribute"', () => {
+      const expected = 'The unsafeHTML update must be used on content, not on an attribute.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" maybe="${unsafeHTML(maybe)}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used on a "boolean-attribute"', () => {
+      const expected = 'The unsafeHTML update must be used on content, not on a boolean-attribute.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" ?maybe="${unsafeHTML(maybe)}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used with a "property"', () => {
+      const expected = 'The unsafeHTML update must be used on content, not on a property.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" .maybe="${unsafeHTML(maybe)}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used with "text-content"', () => {
+      const expected = 'The unsafeHTML update must be used on content, not on text-content.';
+      const getTemplate = ({ maybe }) => {
+        return html`<textarea id="target">${unsafeHTML(maybe)}</textarea>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws for non-string value', () => {
+      const getTemplate = ({ content }) => {
+        return html`
+          <div id="target">
+            ${unsafeHTML(content)}
+          </div>
+        `;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let error;
+      try {
+        render(container, getTemplate({ content: null }));
+      } catch (e) {
+        error = e;
+      }
+      assert(error?.message === 'Unexpected unsafeHTML value "null".', error?.message);
+      container.remove();
+    });
+  });
+
+  describe('unsafeSVG', () => {
+    it('throws if used on an "attribute"', () => {
+      const expected = 'The unsafeSVG update must be used on content, not on an attribute.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" maybe="${unsafeSVG(maybe)}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used on a "boolean-attribute"', () => {
+      const expected = 'The unsafeSVG update must be used on content, not on a boolean-attribute.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" ?maybe="${unsafeSVG(maybe)}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used with a "property"', () => {
+      const expected = 'The unsafeSVG update must be used on content, not on a property.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" .maybe="${unsafeSVG(maybe)}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used with "text-content"', () => {
+      const expected = 'The unsafeSVG update must be used on content, not on text-content.';
+      const getTemplate = ({ maybe }) => {
+        return html`<textarea id="target">${unsafeSVG(maybe)}</textarea>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws for non-string value', () => {
+    const getTemplate = ({ content }) => {
+      return html`
+        <svg id="target" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+          ${unsafeSVG(content)}
+        </svg>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    let error;
+    try {
+      render(container, getTemplate({ content: null }));
+    } catch (e) {
+      error = e;
+    }
+    assert(error?.message === 'Unexpected unsafeSVG value "null".', error?.message);
+    container.remove();
+  });
+  });
+
+  describe('map', () => {
+    it('throws if identify is not a function', () => {
+      const expected = 'Unexpected map identify "undefined" provided, expected a function.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" maybe="${map(maybe)}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if callback is not a function', () => {
+      const expected = 'Unexpected map callback "undefined" provided, expected a function.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" maybe="${map(maybe, () => {})}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used on an "attribute"', () => {
+      const expected = 'The map update must be used on content, not on an attribute.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" maybe="${map(maybe, () => {}, () => {})}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used on a "boolean-attribute"', () => {
+      const expected = 'The map update must be used on content, not on a boolean-attribute.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" ?maybe="${map(maybe, () => {}, () => {})}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used with a "property"', () => {
+      const expected = 'The map update must be used on content, not on a property.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" .maybe="${map(maybe, () => {}, () => {})}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used with "text-content"', () => {
+      const expected = 'The map update must be used on content, not on text-content.';
+      const getTemplate = ({ maybe }) => {
+        return html`<textarea id="target">${map(maybe, () => {}, () => {})}</textarea>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws for non-array value', () => {
+      const getTemplate = ({ array }) => {
+        return html`
+          <div id="target">
+            ${map(array, () => {}, () => html``)}
+          </div>
+        `;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let error;
+      try {
+        render(container, getTemplate({ array: 5 }));
+      } catch (e) {
+        error = e;
+      }
+      assert(error?.message === 'Unexpected map value "5".', error?.message);
+      container.remove();
+    });
+
+    it('throws for non-template callback value', () => {
+      const getTemplate = ({ array }) => {
+        return html`
+          <div id="target">
+            ${map(array, item => item.id, item => item.value ? html`<div>${item.value}</div>` : null)}
+          </div>
+        `;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let error;
+      try {
+        render(container, getTemplate({ array: [{ id: 'foo', value: null }] }));
+      } catch (e) {
+        error = e;
+      }
+      assert(error?.message === 'Unexpected map value "null" provided by callback.', error?.message);
+      container.remove();
+    });
+
+    it('throws for non-template callback value (on re-render)', () => {
+      const getTemplate = ({ array }) => {
+        return html`
+          <div id="target">
+            ${map(array, item => item.id, item => item.value ? html`<div>${item.value}</div>` : null)}
+          </div>
+        `;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      render(container, getTemplate({ array: [{ id: 'foo', value: 'oh hai' }] }));
+      let error;
+      try {
+        render(container, getTemplate({ array: [{ id: 'foo', value: null }] }));
+      } catch (e) {
+        error = e;
+      }
+      assert(error?.message === 'Unexpected map value "null" provided by callback.', error?.message);
+      container.remove();
+    });
+  });
+
+  describe('repeat', () => {
+    it('throws if callback is not a function (1)', () => {
+      const expected = 'Unexpected repeat identify "undefined" provided, expected a function.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" maybe="${repeat(maybe)}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if callback is not a function (2)', () => {
+      const expected = 'Unexpected repeat callback "5" provided, expected a function.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" maybe="${repeat(maybe, 5)}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used on an "attribute"', () => {
+      const expected = 'The repeat update must be used on content, not on an attribute.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" maybe="${repeat(maybe, () => {})}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used on a "boolean-attribute"', () => {
+      const expected = 'The repeat update must be used on content, not on a boolean-attribute.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" ?maybe="${repeat(maybe, () => {})}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used with a "property"', () => {
+      const expected = 'The repeat update must be used on content, not on a property.';
+      const getTemplate = ({ maybe }) => {
+        return html`<div id="target" .maybe="${repeat(maybe, () => {})}"></div>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws if used with "text-content"', () => {
+      const expected = 'The repeat update must be used on content, not on text-content.';
+      const getTemplate = ({ maybe }) => {
+        return html`<textarea id="target">${repeat(maybe, () => {})}</textarea>`;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let actual;
+      try {
+        render(container, getTemplate({ maybe: 'yes' }));
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+      container.remove();
+    });
+
+    it('throws for non-array value', () => {
+      const getTemplate = ({ array }) => {
+        return html`
+          <div id="target">
+            ${repeat(array, () => {}, () => html``)}
+          </div>
+        `;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let error;
+      try {
+        render(container, getTemplate({ array: 5 }));
+      } catch (e) {
+        error = e;
+      }
+      assert(error?.message === 'Unexpected repeat value "5".', error?.message);
+      container.remove();
+    });
+
+    it('throws for non-template callback value', () => {
+      const getTemplate = ({ array }) => {
+        return html`
+          <div id="target">
+            ${repeat(array, item => item.id, item => item.value ? html`<div>${item.value}</div>` : null)}
+          </div>
+        `;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      let error;
+      try {
+        render(container, getTemplate({ array: [{ id: 'foo', value: null }] }));
+      } catch (e) {
+        error = e;
+      }
+      assert(error?.message === 'Unexpected repeat value "null" provided by callback.', error?.message);
+      container.remove();
+    });
+
+    it('throws for non-template callback value (on re-render)', () => {
+      const getTemplate = ({ array }) => {
+        return html`
+          <div id="target">
+            ${repeat(array, item => item.id, item => item.value ? html`<div>${item.value}</div>` : null)}
+          </div>
+        `;
+      };
+      const container = document.createElement('div');
+      document.body.append(container);
+      render(container, getTemplate({ array: [{ id: 'foo', value: 'oh hai' }] }));
+      let error;
+      try {
+        render(container, getTemplate({ array: [{ id: 'foo', value: null }] }));
+      } catch (e) {
+        error = e;
+      }
+      assert(error?.message === 'Unexpected repeat value "null" provided by callback.', error?.message);
+      container.remove();
+    });
+  });
+
+  describe('native array', () => {
+    it('throws for non-template value', () => {
+    const getTemplate = ({ items }) => {
+      return html`
+        <svg id="target" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+          ${items.map(item => item ? html`<div>${item}</div>` : null)}
+        </svg>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    let error;
+    try {
+      render(container, getTemplate({ items: [null] }));
+    } catch (e) {
+      error = e;
+    }
+    assert(error?.message === 'Unexpected array value "null" provided by callback.', error?.message);
+    container.remove();
+  });
+
+    it('throws for non-template value on re-render', () => {
+    const getTemplate = ({ items }) => {
+      return html`
+        <svg id="target" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+          ${items.map(item => item ? html`<div>${item}</div>` : null)}
+        </svg>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, getTemplate({ items: ['foo'] }));
+    let error;
+    try {
+      render(container, getTemplate({ items: [null] }));
+    } catch (e) {
+      error = e;
+    }
+    assert(error?.message === 'Unexpected array value "null" provided by callback.', error?.message);
+    container.remove();
+  });
+  });
+});
+
+describe('interface migration errors', () => {
+  const removedInterfaceNames = [
+    'asyncAppend', 'asyncReplace', 'cache', 'classMap', 'directive', 'guard',
+    'styleMap', 'templateContent', 'until',
+  ];
+  for (const name of removedInterfaceNames) {
+    it(`warns that "${name}" no longer exists.`, () => {
+      const expected = `Removed "${name}" from default templating engine interface. Import and plug-in "lit-html" as your element's templating engine if you want this functionality.`;
+      let actual;
+      try {
+        XElement.templateEngine[name]();
+      } catch (error) {
+        actual = error.message;
+      }
+      assert(!!actual, 'No error was thrown.');
+      assert(actual === expected, actual);
+    });
+  }
+});

--- a/test/x-test.js
+++ b/test/x-test.js
@@ -1,3 +1,3 @@
 // Simply import / export so that we pin this version in one spot.
-import { test, it, skip, todo, waitFor, assert, cover } from 'https://unpkg.com/@netflix/x-test@1.0.0-rc.16/x-test.js';
-export { test, it, skip, todo, waitFor, assert, cover };
+import { test, describe, it, waitFor, assert, coverage } from 'https://unpkg.com/@netflix/x-test@1.0.0-rc.20/x-test.js';
+export { test, describe, it, waitFor, assert, coverage };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,26 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.5.5":
-  version "7.6.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.2.tgz#c3d6e41b304ef10dcf13777a33e7694ec4a9a6dd"
-  integrity sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==
+"@babel/code-frame@^7.0.0":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
+  integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
   dependencies:
-    regenerator-runtime "^0.13.2"
+    "@babel/highlight" "^7.18.6"
+
+"@babel/helper-validator-identifier@^7.18.6":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
+  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
+
+"@babel/highlight@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
+  integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.18.6"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
 
 "@eslint/eslintrc@^2.0.0":
   version "2.0.0"
@@ -128,6 +142,13 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+  dependencies:
+    color-convert "^1.9.0"
+
 ansi-styles@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
@@ -182,6 +203,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
@@ -208,6 +236,15 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+chalk@^2.0.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chalk@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
@@ -229,12 +266,31 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+chromium-bidi@0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-0.4.5.tgz#a352e755536dde609bd2c77e4b1f0906bff8784e"
+  integrity sha512-rkav9YzRfAshSTG3wNXF7P7yNiI29QAo1xBXElPoCoSQR5n20q3cOyVhDv6S7+GlF/CJ/emUxlQiR0xOPurkGg==
+  dependencies:
+    mitt "3.0.0"
+
+color-convert@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+  dependencies:
+    color-name "1.1.3"
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
+
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 color-name@~1.1.4:
   version "1.1.4"
@@ -250,6 +306,16 @@ corser@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/corser/-/corser-2.0.1.tgz#8eda252ecaab5840dcd975ceb90d9370c819ff87"
   integrity sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==
+
+cosmiconfig@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.1.0.tgz#947e174c796483ccf0a48476c24e4fefb7e1aea8"
+  integrity sha512-0tLZ9URlPGU7JsKq0DQOQ3FoRsYX8xDZ7xMiATQfaiGMz7EHowNkbU9u1coAOmnh9p/1ySpm0RB3JNWRXM5GCg==
+  dependencies:
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
 
 cross-fetch@3.1.5:
   version "3.1.5"
@@ -293,10 +359,10 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-devtools-protocol@0.0.981744:
-  version "0.0.981744"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.981744.tgz#9960da0370284577d46c28979a0b32651022bacf"
-  integrity sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==
+devtools-protocol@0.0.1094867:
+  version "0.0.1094867"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1094867.tgz#2ab93908e9376bd85d4e0604aa2651258f13e374"
+  integrity sha512-pmMDBKiRVjh0uKK6CT1WqZmM3hBVSgD+N2MrgyV1uNizAZMw4tx6i/RTc+/uCsKSCmg0xXx7arCP/OFcIwTsiQ==
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -311,6 +377,18 @@ end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
+  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
+  dependencies:
+    is-arrayish "^0.2.1"
+
+escape-string-regexp@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -431,10 +509,10 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-events-to-array@^1.0.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/events-to-array/-/events-to-array-1.1.2.tgz#2d41f563e1fe400ed4962fe1a4d5c6a7539df7f6"
-  integrity sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=
+events-to-array@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/events-to-array/-/events-to-array-2.0.3.tgz#0cd5ee538baae3ea9ec07539d778a2a6056699bc"
+  integrity sha512-f/qE2gImHRa4Cp2y1stEOSgw8wTFyUdVJX7G//bMwbaV9JqISFxg99NbmVQeP7YLnDUZ2un851jlaDrlpmGehQ==
 
 extract-zip@2.0.1:
   version "2.0.1"
@@ -487,14 +565,6 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
-
-find-up@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
-  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
-  dependencies:
-    locate-path "^5.0.0"
-    path-exists "^4.0.0"
 
 find-up@^5.0.0:
   version "5.0.0"
@@ -572,6 +642,16 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^9.2.0:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-9.3.0.tgz#be6e50d172d025c3fcf87903ae25b36b787c0bb0"
+  integrity sha512-EAZejC7JvnQINayvB/7BJbpZpNOJ8Lrw2OZNEvQxe0vaLn1SuwMcfV7/MNaX8L/T0wmptBFI4YMtDvSBxYDc7w==
+  dependencies:
+    fs.realpath "^1.0.0"
+    minimatch "^7.4.1"
+    minipass "^4.2.4"
+    path-scurry "^1.6.1"
+
 globals@^13.19.0:
   version "13.20.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.20.0.tgz#ea276a1e508ffd4f1612888f9d1bad1e2717bf82"
@@ -583,6 +663,11 @@ grapheme-splitter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -700,6 +785,11 @@ inherits@2, inherits@^2.0.3, inherits@^2.0.4:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+  integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -734,12 +824,22 @@ js-sdsl@^4.1.4:
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.3.0.tgz#aeefe32a451f7af88425b11fdb5f58c90ae1d711"
   integrity sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==
 
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
 js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
+
+json-parse-even-better-errors@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
+  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -759,12 +859,10 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-locate-path@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
-  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
-  dependencies:
-    p-locate "^4.1.0"
+lines-and-columns@^1.1.6:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
+  integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
 locate-path@^6.0.0:
   version "6.0.0"
@@ -782,6 +880,11 @@ lodash@^4.17.14:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+lru-cache@^7.14.1:
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
+  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
 mime@^1.6.0:
   version "1.6.0"
@@ -802,17 +905,27 @@ minimatch@^3.0.5, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^7.4.1:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-7.4.2.tgz#157e847d79ca671054253b840656720cb733f10f"
+  integrity sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-minipass@^3.0.0:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
-  integrity sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
-  dependencies:
-    yallist "^4.0.0"
+minipass@^4.0.2, minipass@^4.2.4:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.5.tgz#9e0e5256f1e3513f8c34691dd68549e85b2c8ceb"
+  integrity sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==
+
+mitt@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.0.tgz#69ef9bd5c80ff6f57473e8d89326d01c414be0bd"
+  integrity sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==
 
 mkdirp-classic@^0.5.2:
   version "0.5.3"
@@ -872,26 +985,12 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
-p-limit@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
-  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
-  dependencies:
-    p-try "^2.0.0"
-
 p-limit@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
     yocto-queue "^0.1.0"
-
-p-locate@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
-  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
-  dependencies:
-    p-limit "^2.2.0"
 
 p-locate@^5.0.0:
   version "5.0.0"
@@ -900,17 +999,22 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
-p-try@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
-  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
-
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse-json@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
+  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-even-better-errors "^2.3.0"
+    lines-and-columns "^1.1.6"
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -927,17 +1031,23 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
+path-scurry@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.6.1.tgz#dab45f7bb1d3f45a0e271ab258999f4ab7e23132"
+  integrity sha512-OW+5s+7cw6253Q4E+8qQ/u1fVvcJQCJo/VFD8pje+dbJCF1n5ZRMV2AEHbGp+5Q7jxQIYJxkHopnj6nzdGeZLA==
+  dependencies:
+    lru-cache "^7.14.1"
+    minipass "^4.0.2"
+
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
 pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
-
-pkg-dir@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
-  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
-  dependencies:
-    find-up "^4.0.0"
 
 portfinder@^1.0.28:
   version "1.0.32"
@@ -976,23 +1086,33 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@^13.4.0:
-  version "13.7.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-13.7.0.tgz#18e16f83e397cf02f7a0804c67c1603d381cfb0b"
-  integrity sha512-U1uufzBjz3+PkpCxFrWzh4OrMIdIb2ztzCu0YEPfRHjHswcSwHZswnK+WdsOQJsRV8WeTg3jLhJR4D867+fjsA==
+puppeteer-core@19.7.5:
+  version "19.7.5"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-19.7.5.tgz#cedc8eb7862fe7a8aa2a25ed167c0f1230de72b2"
+  integrity sha512-EJuNha+SxPfaYFbkoWU80H3Wb1SiQH5fFyb2xdbWda0ziax5mhV63UMlqNfPeTDIWarwtR4OIcq/9VqY8HPOsg==
   dependencies:
+    chromium-bidi "0.4.5"
     cross-fetch "3.1.5"
     debug "4.3.4"
-    devtools-protocol "0.0.981744"
+    devtools-protocol "0.0.1094867"
     extract-zip "2.0.1"
     https-proxy-agent "5.0.1"
-    pkg-dir "4.2.0"
-    progress "2.0.3"
     proxy-from-env "1.1.0"
-    rimraf "3.0.2"
+    rimraf "4.4.0"
     tar-fs "2.1.1"
     unbzip2-stream "1.4.3"
-    ws "8.5.0"
+    ws "8.12.1"
+
+puppeteer@^19.7.5:
+  version "19.7.5"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-19.7.5.tgz#d7db0dfcc80ca2cdf8eb0100bae1ce888a841389"
+  integrity sha512-UqD8K+yaZa6/hwzP54AATCiHrEYGGxzQcse9cZzrtsVGd8wT0llCdYhsBp8n+zvnb1ofY0YFgI3TYZ/MiX5uXQ==
+  dependencies:
+    cosmiconfig "8.1.0"
+    https-proxy-agent "5.0.1"
+    progress "2.0.3"
+    proxy-from-env "1.1.0"
+    puppeteer-core "19.7.5"
 
 qs@^6.4.0:
   version "6.11.1"
@@ -1015,11 +1135,6 @@ readable-stream@^3.1.1, readable-stream@^3.4.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-regenerator-runtime@^0.13.2:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
-  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
-
 regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
@@ -1040,7 +1155,14 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@3.0.2, rimraf@^3.0.2:
+rimraf@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-4.4.0.tgz#c7a9f45bb2ec058d2e60ef9aca5167974313d605"
+  integrity sha512-X36S+qpCUR0HjXlkDe4NAOhS//aHH0Z+h8Ckf2auGJk3PTnx5rLmrHkwNdbVQuCSUhOyFrlRvFEllZOYE+yZGQ==
+  dependencies:
+    glob "^9.2.0"
+
+rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -1119,6 +1241,13 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+supports-color@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+  dependencies:
+    has-flag "^3.0.0"
+
 supports-color@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
@@ -1126,21 +1255,20 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-tap-parser@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/tap-parser/-/tap-parser-10.0.1.tgz#b63c2500eeef2be8fbf09d512914196d1f12ebec"
-  integrity sha512-qdT15H0DoJIi7zOqVXDn9X0gSM68JjNy1w3VemwTJlDnETjbi6SutnqmBfjDJAwkFS79NJ97gZKqie00ZCGmzg==
+tap-parser@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/tap-parser/-/tap-parser-12.0.1.tgz#052586bd1013e190c6320563f8b358619e6b6fb7"
+  integrity sha512-MHeYGwFyDxmIbDWoOp52gQze6iBh6R2c9rgfhyhCsxMHAbgggEDn0EmL/RFtra8XJY4fjV6E4CiyBTiHkiCBsg==
   dependencies:
-    events-to-array "^1.0.1"
-    minipass "^3.0.0"
-    tap-yaml "^1.0.0"
+    events-to-array "^2.0.3"
+    tap-yaml "^1.0.2"
 
-tap-yaml@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/tap-yaml/-/tap-yaml-1.0.0.tgz#4e31443a5489e05ca8bbb3e36cef71b5dec69635"
-  integrity sha512-Rxbx4EnrWkYk0/ztcm5u3/VznbyFJpyXO12dDBHKWiDVxy7O2Qw6MRrwO5H6Ww0U5YhRY/4C/VzWmFPhBQc4qQ==
+tap-yaml@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tap-yaml/-/tap-yaml-1.0.2.tgz#62032a459e5524e10661c19ee9df5d33d78812fa"
+  integrity sha512-GegASpuqBnRNdT1U+yuUPZ8rEU64pL35WPBpCISWwff4dErS2/438barz7WFJl4Nzh3Y05tfPidZnH+GaV1wMg==
   dependencies:
-    yaml "^1.5.0"
+    yaml "^1.10.2"
 
 tar-fs@2.1.1:
   version "2.1.1"
@@ -1259,22 +1387,15 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-ws@8.5.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
-  integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
+ws@8.12.1:
+  version "8.12.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.1.tgz#c51e583d79140b5e42e39be48c934131942d4a8f"
+  integrity sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==
 
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
-
-yaml@^1.5.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.7.0.tgz#b4cddb83490051e6c4b6ffe2bb08221c23f4c6cf"
-  integrity sha512-BEXCJKbbJmDzjuG4At0R4nHJKlP81hxoLQqUCaxzqZ8HHgjAlOXbiOHVCQ4YuQqO/rLR8HoQ6kxGkYJ3tlKIsg==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
+yaml@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
Some notes:
* “x-test” comes with grouping features, so that’s leveraged a bit.
* “x-test” now produces TAP 14, so we can bump “tap-parser” as well.
* “puppeteer” bumps from 13.x >> 19.x — fortunately nothing broke us.