### PR TITLE
Update import paths for networked demos.

### DIFF
--- a/demo/lit-html/base-element.js
+++ b/demo/lit-html/base-element.js
@@ -1,19 +1,19 @@
 import XElement from '../../x-element.js';
-import { asyncAppend } from 'https://unpkg.com/lit-html/directives/async-append.js?module';
-import { asyncReplace } from 'https://unpkg.com/lit-html/directives/async-replace.js?module';
-import { cache } from 'https://unpkg.com/lit-html/directives/cache.js?module';
-import { classMap } from 'https://unpkg.com/lit-html/directives/class-map.js?module';
-import { directive } from 'https://unpkg.com/lit-html/directive.js?module';
-import { guard } from 'https://unpkg.com/lit-html/directives/guard.js?module';
-import { html, render as originalRender, svg } from 'https://unpkg.com/lit-html/lit-html.js?module';
-import { ifDefined } from 'https://unpkg.com/lit-html/directives/if-defined.js?module';
-import { live } from 'https://unpkg.com/lit-html/directives/live.js?module';
-import { repeat } from 'https://unpkg.com/lit-html/directives/repeat.js?module';
-import { styleMap } from 'https://unpkg.com/lit-html/directives/style-map.js?module';
-import { templateContent } from 'https://unpkg.com/lit-html/directives/template-content.js?module';
-import { unsafeHTML } from 'https://unpkg.com/lit-html/directives/unsafe-html.js?module';
-import { unsafeSVG } from 'https://unpkg.com/lit-html/directives/unsafe-svg.js?module';
-import { until } from 'https://unpkg.com/lit-html/directives/until.js?module';
+import { asyncAppend } from 'https://unpkg.com/lit-html/directives/async-append.js';
+import { asyncReplace } from 'https://unpkg.com/lit-html/directives/async-replace.js';
+import { cache } from 'https://unpkg.com/lit-html/directives/cache.js';
+import { classMap } from 'https://unpkg.com/lit-html/directives/class-map.js';
+import { directive } from 'https://unpkg.com/lit-html/directive.js';
+import { guard } from 'https://unpkg.com/lit-html/directives/guard.js';
+import { html, render as originalRender, svg } from 'https://unpkg.com/lit-html/lit-html.js';
+import { ifDefined } from 'https://unpkg.com/lit-html/directives/if-defined.js';
+import { live } from 'https://unpkg.com/lit-html/directives/live.js';
+import { repeat } from 'https://unpkg.com/lit-html/directives/repeat.js';
+import { styleMap } from 'https://unpkg.com/lit-html/directives/style-map.js';
+import { templateContent } from 'https://unpkg.com/lit-html/directives/template-content.js';
+import { unsafeHTML } from 'https://unpkg.com/lit-html/directives/unsafe-html.js';
+import { unsafeSVG } from 'https://unpkg.com/lit-html/directives/unsafe-svg.js';
+import { until } from 'https://unpkg.com/lit-html/directives/until.js';
 
 export default class BaseElement extends XElement {
   // Use lit-html's template engine rather than the built-in x-element engine.

--- a/demo/performance/index.js
+++ b/demo/performance/index.js
@@ -1,6 +1,6 @@
 import XElement from '../../x-element.js';
-import { html as litHtmlHtml, render as litHtmlRender } from 'https://unpkg.com/lit-html/lit-html.js?module';
-import { render as uhtmlRender, html as uhtmlHtml } from 'https://unpkg.com/uhtml?module';
+import { html as litHtmlHtml, render as litHtmlRender } from 'https://unpkg.com/lit-html/lit-html.js';
+import { render as uhtmlRender, html as uhtmlHtml } from 'https://unpkg.com/uhtml';
 
 class LitHtmlElement extends XElement {
   // Use lit-html's template engine rather than the built-in x-element engine.

--- a/demo/uhtml/base-element.js
+++ b/demo/uhtml/base-element.js
@@ -1,5 +1,5 @@
 import XElement from '../../x-element.js';
-import { render, html, svg } from 'https://unpkg.com/uhtml?module';
+import { render, html, svg } from 'https://unpkg.com/uhtml';
 
 export default class BaseElement extends XElement {
   // Use µhtml's template engine rather than the built-in x-element engine.


### PR DESCRIPTION
In a some places, we demo loading 3rd party dependencies over-the-wire. The latest versions of these dependencies on `unpkg` require a slightly different url. Just a minor change to update those.