### PR TITLE
Leverage error “cause” for wrapping render errors.

### DIFF
--- a/x-element.js
+++ b/x-element.js
@@ -123,8 +123,8 @@ export default class XElement extends HTMLElement {
       render(renderRoot, result);
     } catch (error) {
       const pathString = XElement.#toPathString(this);
-      error.message = `${error.message} — Invalid template for "${this.constructor.name}" at path "${pathString}"`;
-      throw error;
+      const message = `${error.message} — Invalid template for "${this.constructor.name}" at path "${pathString}"`;
+      throw new Error(message, { cause: error });
     }
   }
 


### PR DESCRIPTION
Because some template engines can throw _immutable_ errors, it’s safer and better to use an “error cause” to _chain_ the old error to our own versus trying to mutate the original.

Closes #128.