### PR TITLE
Fix: Repeat/Map now always rerender.

### DIFF
--- a/test/test-template-engine.js
+++ b/test/test-template-engine.js
@@ -532,6 +532,36 @@ describe('html updaters', () => {
     container.remove();
   });
 
+  it('repeat re-runs each time', () => {
+    const getTemplate = ({ items, lookup }) => {
+      return html`
+      <div>
+        <ul id="target">
+          ${repeat(items, item => item.id, item => {
+            return html`<li id="${item.id}">${lookup?.[item.id]}</li>`;
+          })}
+        </ul>
+      </div>
+    `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    const items = [{ id: 'a' }, { id: 'b'}, { id: 'c' }];
+    let lookup = { a: 'foo', b: 'bar', c: 'baz' };
+    render(container, getTemplate({ items, lookup }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#a').textContent === 'foo');
+    assert(container.querySelector('#b').textContent === 'bar');
+    assert(container.querySelector('#c').textContent === 'baz');
+    lookup = { a: 'fizzle', b: 'bop', c: 'fuzz' };
+    render(container, getTemplate({ items, lookup }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#a').textContent === 'fizzle');
+    assert(container.querySelector('#b').textContent === 'bop');
+    assert(container.querySelector('#c').textContent === 'fuzz');
+    container.remove();
+  });
+
   it('map', () => {
     const getTemplate = ({ items }) => {
       return html`
@@ -589,6 +619,36 @@ describe('html updaters', () => {
     assert(container.querySelector('#target').children[0] !== foo);
     assert(container.querySelector('#target').children[1] !== bar);
     assert(container.querySelector('#target').children[2] !== baz);
+    container.remove();
+  });
+
+  it('map: re-renders each time', () => {
+    const getTemplate = ({ items, lookup }) => {
+      return html`
+        <div>
+          <ul id="target">
+            ${map(items, item => item.id, item => {
+              return html`<li id="${ item.id }">${ lookup?.[item.id] }</li>`;
+            })}
+          </ul>
+        </div>
+      `;
+    };
+    const container = document.createElement('div');
+    document.body.append(container);
+    const items = [{ id: 'a' }, { id: 'b'}, { id: 'c' }];
+    let lookup = { a: 'foo', b: 'bar', c: 'baz' };
+    render(container, getTemplate({ items, lookup }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#a').textContent === 'foo');
+    assert(container.querySelector('#b').textContent === 'bar');
+    assert(container.querySelector('#c').textContent === 'baz');
+    lookup = { a: 'fizzle', b: 'bop', c: 'fuzz' };
+    render(container, getTemplate({ items, lookup }));
+    assert(container.querySelector('#target').childElementCount === 3);
+    assert(container.querySelector('#a').textContent === 'fizzle');
+    assert(container.querySelector('#b').textContent === 'bop');
+    assert(container.querySelector('#c').textContent === 'fuzz');
     container.remove();
   });
 

--- a/x-element.js
+++ b/x-element.js
@@ -1583,13 +1583,11 @@ class Template {
 
   static #map(type, value, lastValue, { node, startNode }, { identify, callback }, name) {
     if (type === 'content') {
-      if (value !== lastValue) {
-        if (Array.isArray(value)) {
-          const internals = Template.#setIfMissing(Template.#internals, startNode, () => ({}));
-          Template.#mapInner(internals, node, startNode, identify, callback, value, name);
-        } else {
-          throw new Error(`Unexpected ${name} value "${value}".`);
-        }
+      if (Array.isArray(value)) {
+        const internals = Template.#setIfMissing(Template.#internals, startNode, () => ({}));
+        Template.#mapInner(internals, node, startNode, identify, callback, value, name);
+      } else {
+        throw new Error(`Unexpected ${name} value "${value}".`);
       }
     } else {
       throw new Error(`The ${name} update must be used on ${Template.#getTypeText('content')}, not on ${Template.#getTypeText(type)}.`);


### PR DESCRIPTION
Resolves #179 

Previously, the repeat and map functions were unable to rerender their contents at all unless the reference to the value they're iterating over changed. This change makes it to where, by default, repeat and map will run their template every time the template function renders, and adds a feature for memoizing the output with a cache key function if desired.

This merge request also adds documentation about the limitations of reactively re-rendering based on arrays and other complex data, and details workarounds/strategies for dealing with this.

As one more change, I've added `.nvmrc` to gitignore so that people using it don't pollute the repo. If desired, I could instead add the target npm version to its contents.

**Testing instructions**:

1. Create this element that leverages repeat:

```javascript
import XElement from '../../x-element.js';

const entries = [{id: 'foo', value: 'FooValue', text: 'FooText'}, {id: 'bar', value: 'BarValue', text: 'BarText'}]

class MySelect extends XElement {
  static get properties() {
    return {
      selectedId: {
        type: String,
        default: 'foo',
        reflect: true,
      },
      options: {
        type: Array,
        // Will run once on load and then never again unless the array is replaced.
        observe: () => console.log('I ran!'),
        default: () => entries,
      },
    };
  }

  static template(html, {repeat}) {
    return ({ options, selectedId }) => {
      return html`
      <div>${selectedId}</div>
      <div>${JSON.stringify(options)}</div>
      <select name="my-options">
        ${repeat(options, option => option.id, option => html`
          <option value="${option.value}" ?selected="${option.id === selectedId}">${option.text}, ${selectedId}</option>
        `)}
      </select>
    `;
    };
  }
}

customElements.define('my-select', MySelect);
// We will edit this in the console.
window.entries = entries
```

Index:

```html
<!doctype html>
<html>
  <head>
    <meta charset="UTF-8">
    <link rel="stylesheet" href="index.css">
    <script type="module" src="index.js"></script>
  </head>
  <body>
    <div>
      <my-select></my-select>
    </div>
  </body>
</html>
```

2. Load this new demo up and access the console. Edit the entries array and note that no re-rending happens, as explained in the new documentation.
3. `let thing = document.querySelector('my-select')`
4. `thing.selectedId = 'bar'`
5. Note that the select/options update, as well as the JSON value and the selected ID value at the top of the component.
6. Edit the original component to add a key function after the callback function for repeat, `() => entries`.
7. Refresh the page. Edit the entries again, and edit the `selectedId` again.
8. Notice that the component re-renders, with the new JSON value, and the new selectedId shown, but the select/ioptions remain unchanged, because the key has not changed (it's a reference to the existing list.)
9. Try different key function outputs to make the re-render work or not work.
10. `npm run test` to run the test suite, or let CI work its magic.

**Author notes and concerns**:

I think this approach is solid overall, but it raises a few questions. First is that there could be performance impacts by making repeat/map render all the time by default. I could change the default to NOT rendering all the time, though I think this behavior would be more surprising than the current one.

The second is that repeat appears to be begrudgingly supported right now, and I've had to add a good bit of repeated code to continue supporting it. This might be a good argument to remove it entirely while we're here, but I don't know what the downstream impact would be for Netflix.

The third is that adding the key function changes the function signature (albeit in a backwards-compatible way) of repeat and map, and these signatures are already a little long.

The fourth is I don't know the code which uses this code-- so I don't have a strong sense of how often repeat and map are used in practice, and whether instead of adding a cache key to repeat/map, I should instead make it to where they always re-render, and instead add some kind of memoization function that can be embedded into the template arbitrarily. Let me know if you'd prefer I do that, instead.

Finally, I'm new to web components and this library-- I only started reading up on the both of them a few days ago in my spare hours. So there's a chance I'm missing something that would be obvious to someone who has worked with them further. Seeing as the issue has been open a while, I figured I'd take a crack at it anyhow :)