### PR TITLE
Perform rendering in a fully  depth-first manner.

### DIFF
--- a/test/test-observed-properties.js
+++ b/test/test-observed-properties.js
@@ -188,3 +188,38 @@ it('x-element observed properties', async () => {
     'no re-entrance for observed, reflected properties'
   );
 });
+
+it('child properties are bound before initialization', () => {
+  const observations = [];
+  class TestInner extends XElement {
+    static get properties() {
+      return {
+        foo: {
+          type: Boolean,
+          observe: (host, value) => observations.push(value),
+          default: false,
+        },
+      };
+    }
+  }
+  customElements.define('test-inner', TestInner);
+  class TestOuter extends XElement {
+    static get properties() {
+      return {
+        foo: {
+          type: Boolean,
+          default: true,
+        },
+      };
+    }
+    static template(html) {
+      return ({ foo }) => html`<test-inner .foo="${foo}"></test-inner>`;
+    }
+  }
+  customElements.define('test-outer', TestOuter);
+  const el = document.createElement('test-outer');
+  document.body.append(el);
+  assert(observations[0] === true, observations[0]);
+  assert(observations.length === 1, observations);
+  el.remove();
+});


### PR DESCRIPTION
Currently, we inject dom into our container and then update bindings. This causes all child “connectedCallback” calls to fire _before_ we bind property / attribute / etc. updates.

That’s problematic because elements have no good way to observe initial deltas in the render tree. Said another way…

We used to do this:
 1. Create new nodes and inject new nodes into our container.
 2. Bind value updates to new nodes.

Now we do this:
 1. Create new nodes.
 2. Bind value updates to new nodes.
 3. Inject new nodes into our container.

Closes #197.