### PR TITLE
Remove nullish coalescing for `textContent`.

### DIFF
--- a/test/test-basic-properties.js
+++ b/test/test-basic-properties.js
@@ -23,6 +23,9 @@ class TestElement extends XElement {
         type: String,
         default: null,
       },
+      undefinedProperty: {
+        type: String,
+      },
       typelessProperty: {},
       typelessPropertyWithCustomAttribute: {
         attribute: 'custom-attribute-typeless',
@@ -33,12 +36,13 @@ class TestElement extends XElement {
     };
   }
   static template(html) {
-    return ({ normalProperty, camelCaseProperty, numericProperty, nullProperty }) => {
+    return ({ normalProperty, camelCaseProperty, numericProperty, nullProperty, undefinedProperty }) => {
       return html`
         <div id="normal">${normalProperty}</div>
         <span id="camel">${camelCaseProperty}</span>
         <span id="num">${numericProperty}</span>
         <span id="nul">${nullProperty}</span>
+        <span id="undef">${undefinedProperty}</span>
       `;
     };
   }
@@ -58,6 +62,12 @@ it('renders an empty string in place of null value', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.shadowRoot.getElementById('nul').textContent === '');
+});
+
+it('renders an empty string in place of undefined value', () => {
+  const el = document.createElement('test-element');
+  document.body.append(el);
+  assert(el.shadowRoot.getElementById('undef').textContent === '');
 });
 
 it('property setter updates on next micro tick after connect', async () => {
@@ -99,6 +109,7 @@ it('observes all dash-cased versions of public, typeless, serializable, and decl
     'camel-case-property',
     'numeric-property',
     'null-property',
+    'undefined-property',
     'typeless-property',
     'custom-attribute-typeless',
   ];

--- a/x-element.js
+++ b/x-element.js
@@ -1488,10 +1488,11 @@ class TemplateEngine {
         }
         const previousSibling = node.previousSibling;
         if (previousSibling === startNode) {
-          const textNode = document.createTextNode(value ?? '');
+          const textNode = document.createTextNode('');
+          textNode.textContent = value;
           node.parentNode.insertBefore(textNode, node);
         } else {
-          previousSibling.textContent = value ?? '';
+          previousSibling.textContent = value;
         }
       }
     }


### PR DESCRIPTION
The default browser behavior when setting `.textContent` to `null` or `undefined` is to ultimately set the content to `''`†. This is quite different from the behavior of `createTextNode` though… by splitting the text node creation into multiple steps we can consistently leverage `.textContent` and remove the need to `?? ''`.

† Note that the WHATWG spec only defines that behavior for `null`, but
  in practice all modern browsers seem to treat `undefined` similarly.

Here’s the [spec](https://dom.spec.whatwg.org/#dom-node-textcontent) for reference. This is related to #204.