### PR TITLE
Adding a couple minor changes for 2.x interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `ifDefined` updater now deletes the attribute on `null` in addition to
   `undefined`. This makes it behave identically to `nullish`. However, both
   updaters are deprecated and the `??attr` binding should be used instead.
+- Interpolation of `textarea` is stricter. This used to be handled with some
+  leniency — `<textarea>\n ${value} \n</textarea>`. Now, you have to fit the
+  interpolation exactly — `<textarea></textarea>`.
 
 ### Deprecated
 
@@ -27,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   syntax like `??foo="${bar}"`.
 - The `repeat` updater is deprecated, use `map` instead.
 - The `unsafeHTML` and `unsafeSVG` updaters are deprecated, use `unsafe`.
+- The `plaintext` tag is no longer handled. This is a deprecated html tag which
+  required special handling… but it’s unlikely that anyone is using that.
 
 ### Fixed
 


### PR DESCRIPTION
Changes:
* Stricter handling of “textarea” binding. Previously we were overly lenient in how the binding worked which caused automagical behavior. For example, newlines were quietly ignored, which could lead to issues if you really _wanted_ newlines in a default value in a text area control and were actually trying to interpolate between lines. Now, it just throws for that case.
* Spec-compliant attribute traversal. Previously, we relied on the browser convention that attributes in a NamedNodeMap would be iterated over in a particular manner. The spec strictly indicates that this is not to be relied on — so we can oblige.
* The deprecated `plaintext` html tag is no longer considered. Use at your own peril…
* General improvements to inline documentation and naming of things.