### PR TITLE
Allow template interpolation escapes (i.e., “\$”).

### DIFF
--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -167,6 +167,7 @@ describe('JS-y escapes', () => {
       The \\u2026, \\\\u2026 character is an ellipsis.
       The \\x8230, \\\\x8230 character is also an ellipsis.
       The \\0, \\\\0 character is the nul character.
+      The \${interpolation} character is okay to escape.
     `;
   });
 });

--- a/x-parser.js
+++ b/x-parser.js
@@ -368,14 +368,14 @@ class Unforgiving {
   // Note that syntax highlighters expect the text after the “html” tag to be
   //  real HTML. Another reason to reject JS-y unicode is that it won’t be
   //  interpreted correctly by tooling that expects _html_.
-  // The only escapes we expect to see are for the “\” and “`” characters, which
-  //  you _must_ use if you need those literal characters.
+  // The only escapes we expect to see are for the “$”, “\”, and “`” characters,
+  //  which you _must_ use if you need those literal characters.
   // The simplest way to check this is to ensure that back slashes always come
   //  in pairs of two or a single back slash preceding a back tick.
   // Examples:
   //  - ok: html`&#8230;`, html`&#x2026;`, html`&mldr;`, html`&hellip;`, html`\\n`
   //  - not ok: html`\nhi\nthere`, html`\x8230`, html`\u2026`, html`\s\t\o\p\ \i\t\.`
-  static __rawJsEscape = /.*(?<!\\)(?:\\{2})*\\(?![\\`])/ys;
+  static __rawJsEscape = /.*(?<!\\)(?:\\{2})*\\(?![$\\`])/ys;
 
   //////////////////////////////////////////////////////////////////////////////
   // Character References //////////////////////////////////////////////////////


### PR DESCRIPTION
We need to allow _some_ JS-y escapes that cannot otherwise be accomplished through standard HTML syntax. We had already allowed the backtick and backslash characters — just need the dollar sign as well.