### PR TITLE
Prevent disconnects on simple re-mappings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default template engine. This causes us to reject elements like `<title>`,
   `<body>`, `<link>`, `<script>`, `<canvas>`, `<meta>`, etc. (#239).
 
+### Fixed
+
+- When re-rendering a mapping where elements at the beginning or end have been
+  removed — no disconnect / connect lifecycle events will occur. Previously,
+  because we didn’t specifically guard this case, the low-level APIs would cause
+  this to occur, which is unexpected from an integration standpoint (#253).
+
 ## [1.1.2] - 2024-12-16
 
 ### Added

--- a/ts/x-template.d.ts.map
+++ b/ts/x-template.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"x-template.d.ts","sourceRoot":"","sources":["../x-template.js"],"names":[],"mappings":"AAg5BA,yBAA2E;AAC3E,uBAAuE;AAGvE,sBAAqE;AACrE,uBAAuE;AACvE,6BAAmF;AACnF,4BAAiF;AACjF,0BAA6E;AAC7E,yBAA2E"}
+{"version":3,"file":"x-template.d.ts","sourceRoot":"","sources":["../x-template.js"],"names":[],"mappings":"AA05BA,yBAA2E;AAC3E,uBAAuE;AAGvE,sBAAqE;AACrE,uBAAuE;AACvE,6BAAmF;AACnF,4BAAiF;AACjF,0BAA6E;AAC7E,yBAA2E"}


### PR DESCRIPTION
Conceptually, if you render `[foo, bar]` and then re-render with just `[bar]` — you don’t expect that the `foo` element will be disconnected and reconnected. However, if we naively first _move_ `bar` to the first slot and then _delete_ `foo`… that‘s exactly what will happen.

Instead, we must first _delete_ `foo` and then _check_ to see if we still need to _move_ `bar`.

Note that if a shuffle is _actually_ necessary, we cannot prevent a disconnect / reconnect from occurring with the current DOM APIs.

Closes #253