### PR TITLE
Update package.json engines again

### DIFF
--- a/.github/workflows/publish-to-jsr.yaml
+++ b/.github/workflows/publish-to-jsr.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.18'
+          node-version: '22.14'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       # Can we get this to use “deno publish”?

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.18'
+          node-version: '22.14'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm publish

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.18'
+          node-version: '22.14'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
         "typescript": "5.7.3"
       },
       "engines": {
-        "node": ">=20.18",
-        "npm": ">=10.8"
+        "node": ">=22.14",
+        "npm": ">=10.9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "typescript": "5.7.3"
   },
   "engines": {
-    "node": ">=20.18",
-    "npm": ">=10.8"
+    "node": ">=22.14",
+    "npm": ">=10.9"
   },
   "contributors": [
     {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/difference — actually this method depends on Node 22 since 2024