### PR TITLE
Remove “unsafeHTML” from “x-template” interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,20 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   element interfaces, “x-template.js” which is all about DOM management, and
   “x-parser.js” which is all about turning markup into a document fragment.
 
-### Deprecated
-
-- The `<style>` tag is deprecated and will be removed in future versions.
-  Authors should prefer to declare a separate stylesheet in a `.css` file now
-  that “import attributes” are supported in modern browsers (#237).
-
 ### Removed
 
+- The `unsafeHTML`, `nullish`, and `map` updaters are gone (#216).
 - The `<style>` element is now restricted. The spec and conventions for `style`
   differ a lot from `html` and a faster / more-maintainable parser can be built
   if we stop supporting this (#237).
-- The `<svg>` element and the `svg` tagged template function are gone. The spec
-  and conventions for `svg` differ a lot from `html` and a faster /
-  more-maintainable parser can be built if we stop supporting this (#236).
+- The `<svg>` element, the `unsafeSVG` updater, and the `svg` tagged template
+  function are gone. The spec and conventions for `svg` differ a lot from `html`
+  and a faster / more-maintainable parser can be built if we stop supporting
+  this (#236).
 - Support for the `<math>` element is removed from the default template engine.
   This worked before because `innerHTML` was being used under-the-hood. But a
   strict allow-list is now used to accomplish parsing (#238).

--- a/ts/x-element.d.ts
+++ b/ts/x-element.d.ts
@@ -134,9 +134,9 @@ export default class XElement extends HTMLElement {
     /**
      * Setup template callback to update DOM when properties change.
      * ```js
-     * static template(html, { nullish }) {
-     *   return (href) => {
-     *     return html`<a href=${nullish(href)}>click me</a>`;
+     * static template(html) {
+     *   return ({ href }) => {
+     *     return html`<a href="${href}">click me</a>`;
      *   }
      * }
      * ```

--- a/ts/x-template.d.ts
+++ b/ts/x-template.d.ts
@@ -1,9 +1,6 @@
 export const render: any;
 export const html: any;
-export const map: any;
 export const live: any;
-export const unsafeHTML: any;
 export const ifDefined: any;
-export const nullish: any;
 export const repeat: any;
 //# sourceMappingURL=x-template.d.ts.map

--- a/ts/x-template.d.ts.map
+++ b/ts/x-template.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"x-template.d.ts","sourceRoot":"","sources":["../x-template.js"],"names":[],"mappings":"AA05BA,yBAA2E;AAC3E,uBAAuE;AAGvE,sBAAqE;AACrE,uBAAuE;AACvE,6BAAmF;AACnF,4BAAiF;AACjF,0BAA6E;AAC7E,yBAA2E"}
+{"version":3,"file":"x-template.d.ts","sourceRoot":"","sources":["../x-template.js"],"names":[],"mappings":"AA8yBA,yBAA2E;AAC3E,uBAAuE;AAGvE,uBAAuE;AACvE,4BAAiF;AACjF,yBAA2E"}

--- a/x-element.js
+++ b/x-element.js
@@ -143,9 +143,9 @@ export default class XElement extends HTMLElement {
   /**
    * Setup template callback to update DOM when properties change.
    * ```js
-   * static template(html, { nullish }) {
-   *   return (href) => {
-   *     return html`<a href=${nullish(href)}>click me</a>`;
+   * static template(html) {
+   *   return ({ href }) => {
+   *     return html`<a href="${href}">click me</a>`;
    *   }
    * }
    * ```


### PR DESCRIPTION
This isn’t commonly used and developers can simply leverage a browser API like `setHTMLUnsafe` to accomplish the same thing by passing a `DocumentFragment` into the templating engine.

Closes #216