### PR TITLE
Remove “ifDefined” content guards.

### DIFF
--- a/test/test-template-engine.js
+++ b/test/test-template-engine.js
@@ -1191,42 +1191,6 @@ describe('updater errors', () => {
       assert(actual === expected, actual);
       container.remove();
     });
-
-    it('throws if used with "content"', () => {
-      const expected = 'The ifDefined update must be used on an attribute, not on content.';
-      const getTemplate = ({ maybe }) => {
-        return html`<div id="target">${ifDefined(maybe)}</div>`;
-      };
-      const container = document.createElement('div');
-      document.body.append(container);
-      let actual;
-      try {
-        render(container, getTemplate({ maybe: 'yes' }));
-      } catch (error) {
-        actual = error.message;
-      }
-      assert(!!actual, 'No error was thrown.');
-      assert(actual === expected, actual);
-      container.remove();
-    });
-
-    it('throws if used with "text"', () => {
-      const expected = 'The ifDefined update must be used on an attribute, not on text content.';
-      const getTemplate = ({ maybe }) => {
-        return html`<textarea id="target">${ifDefined(maybe)}</textarea>`;
-      };
-      const container = document.createElement('div');
-      document.body.append(container);
-      let actual;
-      try {
-        render(container, getTemplate({ maybe: 'yes' }));
-      } catch (error) {
-        actual = error.message;
-      }
-      assert(!!actual, 'No error was thrown.');
-      assert(actual === expected, actual);
-      container.remove();
-    });
   });
 
   describe('repeat', () => {

--- a/ts/x-template.d.ts.map
+++ b/ts/x-template.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"x-template.d.ts","sourceRoot":"","sources":["../x-template.js"],"names":[],"mappings":"AA6vBA,yBAA2E;AAC3E,uBAAuE;AAGvE,4BAAiF;AACjF,yBAA2E"}
+{"version":3,"file":"x-template.d.ts","sourceRoot":"","sources":["../x-template.js"],"names":[],"mappings":"AAqoBA,yBAA2E;AAC3E,uBAAuE;AAGvE,4BAAiF;AACjF,yBAA2E"}


### PR DESCRIPTION
Developers will no longer get errors thrown related to misused of the “ifDefined” updater. This is not really a case that we need to guard against though as it’s not ever mistakenly done in practice.

Note that the guard _does_ remain in place for now for boolean attributes, defined attributes, and properties (which are common places where mistakes occur). In the future, “ifDefined” will be deleted completely and we’ll be able to do even more cleanup here.

Also, because we removed the “live” in a prior PR, we are also able to move the change-by-reference detection guard up to the top-level “commit” method for improved readability and performance.