### PR TITLE
Replaces “innerHTML” with “setHTMLUnsafe”.

### DIFF
--- a/test/forgiving.js
+++ b/test/forgiving.js
@@ -4,7 +4,7 @@
 //  parsing solution. In particular, it could be interesting to try and keep the
 //  interfaces to both “forgiving” and “unforgiving” as similar as possible to
 //  enable us to show performance-testing deltas in the future.
-/** Forgiving HTML parser which leverages innerHTML. */
+/** Forgiving HTML parser which leverages setHTMLUnsafe. */
 export default class Forgiving {
   // Special markers added to markup enabling discovery post-instantiation.
   static #NEXT_MARKER = 'forgiving-next:'; // The ":" helps for debugging.
@@ -150,7 +150,7 @@ export default class Forgiving {
   static #createFragment(language, strings) {
     const template = document.createElement('template');
     const html = Forgiving.#createHtml(language, strings);
-    template.innerHTML = html;
+    template.setHTMLUnsafe(html);
     return template.content;
   }
 

--- a/test/test-template-engine.js
+++ b/test/test-template-engine.js
@@ -547,11 +547,11 @@ describe('html rendering', () => {
     };
     const container = document.createElement('div');
     const template = document.createElement('template');
-    template.innerHTML = '<input>';
+    template.setHTMLUnsafe('<input>');
     render(container, getTemplate({ fragment: template.content.cloneNode(true) }));
     assert(container.childElementCount === 1);
     assert(container.children[0].localName === 'input');
-    template.innerHTML = '<textarea></textarea>';
+    template.setHTMLUnsafe('<textarea></textarea>');
     render(container, getTemplate({ fragment: template.content.cloneNode(true) }));
     assert(container.childElementCount === 1);
     assert(container.children[0].localName === 'textarea');

--- a/x-template.js
+++ b/x-template.js
@@ -142,7 +142,7 @@ class TemplateEngine {
 
   // We only decode things we know to be encoded since it’s non-performant.
   static #decode(encoded) {
-    this.#htmlEntityContainer.innerHTML = encoded;
+    this.#htmlEntityContainer.setHTMLUnsafe(encoded);
     const decoded = this.#htmlEntityContainer.content.textContent;
     return decoded;
   }


### PR DESCRIPTION
Just leverage the more modern approach in the handful of places that use this in our code (for decoding character references and in tests).

This feature was baselined in 2024.