### PR TITLE
Adds a test related to literal property bindings.

### DIFF
--- a/test/forgiving.js
+++ b/test/forgiving.js
@@ -1,5 +1,3 @@
-// TODO: The `XParser` interface now requires instantiation.
-
 // This is just kept here as an example alternative to our more “unforgiving”
 //  parsing solution. In particular, it could be interesting to try and keep the
 //  interfaces to both “forgiving” and “unforgiving” as similar as possible to

--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -1085,6 +1085,12 @@ describe('errors', () => {
     assertThrows(callback, expectedMessage, { startsWith: true });
   });
 
+  it('throws for misuse of a bound property prefix with a literal value', () => {
+    const callback = () => html`<div .literal="property"></div>`;
+    const expectedMessage = '[#105]';
+    assertThrows(callback, expectedMessage, { startsWith: true });
+  });
+
   it('throws if a bound property starts with an underscore', () => {
     const callback = () => html`<div ._what="${VALUE}"></div>`;
     const expectedMessage = '[#129]';


### PR DESCRIPTION
The default template engine doesn’t allow binding a _literal_ value to a property via the `.` prefix — however, we didn’t previously check this case in our test suite.

Closes #203.