### PR TITLE
Adds arrays to performance test templates.

### DIFF
--- a/demo/performance/common.js
+++ b/demo/performance/common.js
@@ -58,6 +58,7 @@ export default class CommonTest {
       title: 'test',
       content1: 'AAA',
       content2: 'BBB',
+      items: [{ text: 'one' }, { text: 'two' }, { text: 'three' }],
     },
     {
       attr: '456',
@@ -76,6 +77,7 @@ export default class CommonTest {
       title: 'test',
       content1: 'ZZZ',
       content2: 'BBB',
+      items: [{ text: 'one' }, { text: 'two' }, { text: 'three' }, { text: 'four' }, { text: 'five' }, { text: 'six' }],
     },
   ];
 
@@ -235,7 +237,7 @@ export class HtmlLiteralInterface {
   // We can get around the optimization by using eval though!
   static getResultEval(html, properties) {
     // eslint-disable-next-line no-unused-vars
-    const { attr, one, two, three, four, five, six, seven, eight, nine, ten, id, hidden, title, content1, content2 } = properties;
+    const { attr, one, two, three, four, five, six, seven, eight, nine, ten, id, hidden, title, content1, content2, items } = properties;
     // eslint-disable-next-line no-eval
     return eval(`html\`<div data-id="p1" attr="\${attr}">
       <div data-id="p2" data-foo one="\${one}" two="\${two}" three="\${three}" four="\${four}" five="\${five}" .six="\${six}" .seven="\${seven}" .eight="\${eight}" .nine="\${nine}" .ten="\${ten}">
@@ -243,6 +245,11 @@ export class HtmlLiteralInterface {
           <div data-id="\${id}" boolean ?hidden="\${hidden}" .title="\${title}">
             \${content1} -- \${content2}
           </div>
+          <ul data-id="list">
+            \${(items ?? []).map(item => {
+              return html\`<li>\${item.text}</li>\`;
+            })}
+          </ul>
         </div>
       </div>
       <div class="extra">

--- a/demo/performance/react.js
+++ b/demo/performance/react.js
@@ -11,7 +11,7 @@ class Test extends CommonTest {
 
   // TODO: This is sorta cheating since we aren’t asking it to _parse_ anything…
   static getResult(properties) {
-    const { attr, one, two, three, four, five, six, seven, eight, nine, ten, id, hidden, title, content1, content2 } = properties;
+    const { attr, one, two, three, four, five, six, seven, eight, nine, ten, id, hidden, title, content1, content2, items } = properties;
     return createElement('div', { 'data-id': 'p1', attr }, [
       createElement('div', { 'data-id': 'p2', 'data-foo': '', one, two, three, four, five, six, seven, eight, nine, ten }, [
         createElement('div', { 'data-id': 'p3', 'data-bar': 'bar' }, [
@@ -20,6 +20,9 @@ class Test extends CommonTest {
             ' -- ',
             content2,
           ]),
+          createElement('ul', { 'data-id': 'list' }, (items ?? []).map(item => {
+            return createElement('li', null, [item.text]);
+          })),
         ]),
         createElement('p', null, [
           'Just something a little ',

--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -1544,11 +1544,15 @@ describe('errors coverage', () => {
     assertThrows(callback, expectedMessage, { startsWith: true });
   });
 
+  //////////////////////////////////////////////////////////////////////////////
+
   it('throws when cdata exists', () => {
     const callback = () => htmlol`<![CDATA[<]]>`;
     const expectedMessage = '[#140]';
     assertThrows(callback, expectedMessage, { startsWith: true });
   });
+
+  //////////////////////////////////////////////////////////////////////////////
 
   it('throws when escapes are used', () => {
     const callback = () => htmlol`\n`;


### PR DESCRIPTION
Only demo / test changes here — it’s not too hard to support this since most (all?) templating engines will accept a native _array_ as input for a set of children.