### PR TITLE
Lock down CSP in “.html” files to prove we can.

### DIFF
--- a/demo/chess/index.html
+++ b/demo/chess/index.html
@@ -1,7 +1,8 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
     <link rel="stylesheet" href="index.css">
     <script type="module" src="index.js"></script>
   </head>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,7 +1,8 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
     <link rel="stylesheet" href="index.css">
     <script type="module" src="index.js"></script>
   </head>

--- a/demo/lit-html/demo-lit-html.js
+++ b/demo/lit-html/demo-lit-html.js
@@ -1,6 +1,17 @@
 import BaseElement from './base-element.js';
 
 export default class DemoLitHtml extends BaseElement {
+  static get styles() {
+    const styleSheet = new CSSStyleSheet();
+    styleSheet.replaceSync(`
+      #container[emoji]::before {
+        content: " " attr(emoji);
+        font-size: 2rem;
+      }
+    `);
+    return [styleSheet];
+  }
+
   static get properties() {
     return {
       emoji: {
@@ -16,12 +27,6 @@ export default class DemoLitHtml extends BaseElement {
   static template(html, { ifDefined }) {
     return ({ emoji, message }) => {
       return html`
-        <style>
-          #container[emoji]::before {
-            content: " " attr(emoji);
-            font-size: 2rem;
-          }
-        </style>
         <div id="container" emoji="${ifDefined(emoji)}">Rendered &ldquo;${message}&rdquo; using <code>lit-html</code>.</div>
       `;
     };

--- a/demo/lit-html/index.html
+++ b/demo/lit-html/index.html
@@ -1,7 +1,8 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-vpd4e6Q2EYlXOAcBOCPYNRqOSK1caV1iPamby7fBE30=' https://esm.sh/lit-html@3.2.1/;">
     <script type="importmap">
       {
         "imports": {

--- a/demo/performance/default.html
+++ b/demo/performance/default.html
@@ -1,7 +1,10 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
+    <!-- We use “unsafe-eval” below because we need to trick the browser into
+         not caching tagged template string objects to test interpretation. -->
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'unsafe-eval';">
     <link rel="stylesheet" href="./index.css">
   </head>
   <body>

--- a/demo/performance/index.html
+++ b/demo/performance/index.html
@@ -1,7 +1,8 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
     <link rel="stylesheet" href="./index.css">
   </head>
   <body>

--- a/demo/performance/lit-html.html
+++ b/demo/performance/lit-html.html
@@ -1,7 +1,10 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
+    <!-- We use “unsafe-eval” below because we need to trick the browser into
+          not caching tagged template string objects to test interpretation. -->
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' 'sha256-2gPcHEAV/bRWIxMnz3UA5z6w2m9RdFis8ZAa8Y/EZVg=' https://esm.sh/lit-html@3.2.1 https://esm.sh/lit-html@3.2.1/;">
     <script type="importmap">
       {
         "imports": {

--- a/demo/performance/react.html
+++ b/demo/performance/react.html
@@ -1,7 +1,12 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
+    <!-- TODO: The react library has a bunch of dependencies which makes the CSP
+          unwieldy. Rather than enumerate them all, a blanket rule is encoded
+          below to allow any access to https://esm.sh/. You wouldn’t want to do
+          that on a production site, this is just for the demo. -->
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-HVRkfAW4ErWhOQ71jSlHDwiHtimNBYSzVw0wcuf6XwA=' https://esm.sh/;">
     <script type="importmap">
       {
         "imports": {

--- a/demo/performance/uhtml.html
+++ b/demo/performance/uhtml.html
@@ -1,7 +1,14 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
+    <!-- TODO: The uhtml library has a bunch of dependencies which makes the CSP
+          unwieldy. Rather than enumerate them all, a blanket rule is encoded
+          below to allow any access to https://esm.sh/. You wouldn’t want to do
+          that on a production site, this is just for the demo. -->
+    <!-- We use “unsafe-eval” below because we need to trick the browser into
+          not caching tagged template string objects to test interpretation. -->
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' 'sha256-tqJYP2BfE6OLuQk1TacH2iYQga16y7fS413atm5uM9o=' https://esm.sh/;">
     <script type="importmap">
       {
         "imports": {

--- a/demo/react/index.html
+++ b/demo/react/index.html
@@ -1,7 +1,12 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
+    <!-- TODO: The react library has a bunch of dependencies which makes the CSP
+          unwieldy. Rather than enumerate them all, a blanket rule is encoded
+          below to allow any access to https://esm.sh/. You wouldn’t want to do
+          that on a production site, this is just for the demo. -->
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-HVRkfAW4ErWhOQ71jSlHDwiHtimNBYSzVw0wcuf6XwA=' https://esm.sh/;">
     <script type="importmap">
       {
         "imports": {

--- a/demo/uhtml/demo-uhtml.js
+++ b/demo/uhtml/demo-uhtml.js
@@ -1,6 +1,17 @@
 import BaseElement from './base-element.js';
 
 export default class DemoUhtml extends BaseElement {
+  static get styles() {
+    const styleSheet = new CSSStyleSheet();
+    styleSheet.replaceSync(`
+      #container[emoji]::before {
+        content: " " attr(emoji);
+        font-size: 2rem;
+      }
+    `);
+    return [styleSheet];
+  }
+
   static get properties() {
     return {
       emoji: {
@@ -16,12 +27,6 @@ export default class DemoUhtml extends BaseElement {
   static template(html) {
     return ({ emoji, message }) => {
       return html`
-        <style>
-          #container[emoji]::before {
-            content: " " attr(emoji);
-            font-size: 2rem;
-          }
-        </style>
         <div id="container" emoji="${emoji}">Rendered &ldquo;${message}&rdquo; using <code>µhtml</code>.</div>
       `;
     };

--- a/demo/uhtml/index.html
+++ b/demo/uhtml/index.html
@@ -1,7 +1,12 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
+    <!-- TODO: The uhtml library has a bunch of dependencies which makes the CSP
+          unwieldy. Rather than enumerate them all, a blanket rule is encoded
+          below to allow any access to https://esm.sh/. You wouldn’t want to do
+          that on a production site, this is just for the demo. -->
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-tqJYP2BfE6OLuQk1TacH2iYQga16y7fS413atm5uM9o=' https://esm.sh/;">
     <script type="importmap">
       {
         "imports": {

--- a/index.html
+++ b/index.html
@@ -1,7 +1,8 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self';">
     <meta http-equiv="refresh" content="0; url=/demo">
   </head>
   <body></body>

--- a/test/index.html
+++ b/test/index.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-analysis-errors.html
+++ b/test/test-analysis-errors.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-attribute-changed-errors.html
+++ b/test/test-attribute-changed-errors.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-basic-properties.html
+++ b/test/test-basic-properties.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-computed-properties.html
+++ b/test/test-computed-properties.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-default-properties.html
+++ b/test/test-default-properties.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-element-upgrade.html
+++ b/test/test-element-upgrade.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-initial-properties.html
+++ b/test/test-initial-properties.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-initialization-errors.html
+++ b/test/test-initialization-errors.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-internal-properties.html
+++ b/test/test-internal-properties.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-listeners.html
+++ b/test/test-listeners.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-observed-properties.html
+++ b/test/test-observed-properties.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-parser.html
+++ b/test/test-parser.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-read-only-properties.html
+++ b/test/test-read-only-properties.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-reflected-properties.html
+++ b/test/test-reflected-properties.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-render-root.html
+++ b/test/test-render-root.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-render.html
+++ b/test/test-render.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-scratch.html
+++ b/test/test-scratch.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-styles.html
+++ b/test/test-styles.html
@@ -2,8 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA=';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>

--- a/test/test-template-engine.html
+++ b/test/test-template-engine.html
@@ -2,8 +2,15 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <!-- We test that “on*” event handlers work and must loosen our CSP to
+         check that particular test via the “script-src-attr” directive. -->
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'sha256-RVXBMfHRdgc8777jps6ngyVOY4g0I7LMQ7IUzGv2lbA='; script-src-attr 'unsafe-inline';">
     <script type="importmap">
-      { "imports": { "@netflix/x-test/": "../node_modules/@netflix/x-test/" } }
+      {
+        "imports": {
+          "@netflix/x-test/": "../node_modules/@netflix/x-test/"
+        }
+      }
     </script>
   </head>
   <body>


### PR DESCRIPTION
We want integrators to be able to enforce the strictest content security policies possible — this change set places strict CSPs in our own documents to keep us honest.