### PR TITLE
Fix rendering lists of changing length.

### DIFF
--- a/test/test-template-engine.js
+++ b/test/test-template-engine.js
@@ -459,10 +459,40 @@ describe('html rendering', () => {
       `;
     };
     const container = document.createElement('div');
-    render(container, getTemplate({ items: [1, 2, 3] }));
-    assert(container.querySelector('#target').childElementCount === 3);
-    render(container, getTemplate({ items: [1, 2, 3, 4, 5] }));
-    assert(container.querySelector('#target').childElementCount === 5);
+
+    // Render 0 > 1 > 2
+    render(container, getTemplate({ items: [] }));
+    assert(container.querySelector('#target').childElementCount === 0);
+    render(container, getTemplate({ items: [1] }));
+    assert(container.querySelector('#target').childElementCount === 1);
+    render(container, getTemplate({ items: [1, 2] }));
+    assert(container.querySelector('#target').childElementCount === 2);
+
+    // Render 2 > 1 > 0
+    render(container, getTemplate({ items: [1, 2] }));
+    assert(container.querySelector('#target').childElementCount === 2);
+    render(container, getTemplate({ items: [1] }));
+    assert(container.querySelector('#target').childElementCount === 1);
+    render(container, getTemplate({ items: [] }));
+    assert(container.querySelector('#target').childElementCount === 0);
+
+    // Render 0 > 1 > 0 > 1
+    render(container, getTemplate({ items: [] }));
+    assert(container.querySelector('#target').childElementCount === 0);
+    render(container, getTemplate({ items: [1] }));
+    assert(container.querySelector('#target').childElementCount === 1);
+    render(container, getTemplate({ items: [] }));
+    assert(container.querySelector('#target').childElementCount === 0);
+    render(container, getTemplate({ items: [1] }));
+    assert(container.querySelector('#target').childElementCount === 1);
+
+    // Render 0 > 2 > 0 > 2
+    render(container, getTemplate({ items: [] }));
+    assert(container.querySelector('#target').childElementCount === 0);
+    render(container, getTemplate({ items: [1, 2] }));
+    assert(container.querySelector('#target').childElementCount === 2);
+    render(container, getTemplate({ items: [] }));
+    assert(container.querySelector('#target').childElementCount === 0);
     render(container, getTemplate({ items: [1, 2] }));
     assert(container.querySelector('#target').childElementCount === 2);
   });
@@ -782,6 +812,53 @@ describe('html rendering', () => {
     assert(container.querySelector('#target').childElementCount === 1);
     assert(!!container.querySelector('#foo'));
     assert(container.querySelector('#target').children[0] !== foo);
+  });
+
+  it('native map with changing length', () => {
+    const getTemplate = ({ items }) => {
+      return html`
+        <div id="target">
+          ${items.map(item => [item, html`<div class="item"></div>`])}
+        </div>
+      `;
+    };
+    const container = document.createElement('div');
+
+    // Render 0 > 1 > 2
+    render(container, getTemplate({ items: [] }));
+    assert(container.querySelector('#target').childElementCount === 0);
+    render(container, getTemplate({ items: ['1'] }));
+    assert(container.querySelector('#target').childElementCount === 1);
+    render(container, getTemplate({ items: ['1', '2'] }));
+    assert(container.querySelector('#target').childElementCount === 2);
+
+    // Render 2 > 1 > 0
+    render(container, getTemplate({ items: ['1', '2'] }));
+    assert(container.querySelector('#target').childElementCount === 2);
+    render(container, getTemplate({ items: ['1'] }));
+    assert(container.querySelector('#target').childElementCount === 1);
+    render(container, getTemplate({ items: [] }));
+    assert(container.querySelector('#target').childElementCount === 0);
+
+    // Render 0 > 1 > 0 > 1
+    render(container, getTemplate({ items: [] }));
+    assert(container.querySelector('#target').childElementCount === 0);
+    render(container, getTemplate({ items: ['1'] }));
+    assert(container.querySelector('#target').childElementCount === 1);
+    render(container, getTemplate({ items: [] }));
+    assert(container.querySelector('#target').childElementCount === 0);
+    render(container, getTemplate({ items: ['1'] }));
+    assert(container.querySelector('#target').childElementCount === 1);
+
+    // Render 0 > 2 > 0 > 2
+    render(container, getTemplate({ items: [] }));
+    assert(container.querySelector('#target').childElementCount === 0);
+    render(container, getTemplate({ items: ['1', '2'] }));
+    assert(container.querySelector('#target').childElementCount === 2);
+    render(container, getTemplate({ items: [] }));
+    assert(container.querySelector('#target').childElementCount === 0);
+    render(container, getTemplate({ items: ['1', '2'] }));
+    assert(container.querySelector('#target').childElementCount === 2);
   });
 
   // TODO: #254: Uncomment “moves” lines when we leverage “moveBefore”.

--- a/ts/x-template.d.ts.map
+++ b/ts/x-template.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"x-template.d.ts","sourceRoot":"","sources":["../x-template.js"],"names":[],"mappings":"AAk4BA,yBAA2E;AAC3E,uBAAuE;AAGvE,4BAAiF;AACjF,yBAA2E"}
+{"version":3,"file":"x-template.d.ts","sourceRoot":"","sources":["../x-template.js"],"names":[],"mappings":"AAs4BA,yBAA2E;AAC3E,uBAAuE;AAGvE,4BAAiF;AACjF,yBAA2E"}

--- a/x-template.js
+++ b/x-template.js
@@ -470,8 +470,12 @@ class TemplateEngine {
       const index = values.length;
       const id = String(index);
       const item = arrayState.map.get(id);
-      TemplateEngine.#removeThrough(item.startNode, node);
-      arrayState.map.delete(id);
+      TemplateEngine.#removeBetween(item.startNode, node);
+      item.startNode.remove();
+      for (let iii = arrayState.map.size - 1; iii >= values.length; iii--) {
+        // We iterate backwards since we are deleting keys from the map itself.
+        arrayState.map.delete(String(iii));
+      }
     }
   }
 


### PR DESCRIPTION
The root cause of the error here was that we were inadvertently removing
our _outer_ cursor when removing DOM nodes through our inner cursors.

Rather than _remove through_, we need to _remove between_ and then also
remove our one additional inner cursor.

Additionally, we needed to do more to clean up some internal state when
lists are truncated.

Closes #303.