### PR TITLE
Allow binding empty “DocumentFragment” instances.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - There are now three files in this repo — “x-element.js” which is all about
   element interfaces, “x-template.js” which is all about DOM management, and
   “x-parser.js” which is all about interpolated html markup interpretation.
+- An error is no longer thrown when binding an empty document fragment as
+  content in a template (#310).
 
 ### Removed
 

--- a/doc/TEMPLATES.md
+++ b/doc/TEMPLATES.md
@@ -275,20 +275,15 @@ html`<div>${bar}</div>`;
 When the content being bound is a `DocumentFragment` (e.g., from a `<template>`
 element’s `.content` property), the child nodes of that fragment will be added
 via an `.append(fragment)` on the parent container. This _moves_ those nodes
-from the fragment to the container (i.e., _not_ a copy). To prevent developers
-from unintentionally re-binding an already-exhausted fragment, the template
-engine _will throw_ when an empty document fragment is provided.
+from the fragment to the container (i.e., _not_ a copy).
 
 ```js
 const template = document.createElement('template');
-template.setHTMLUnsafe(`<script>console.log('hello world');</script>`);
+template.setHTMLUnsafe(`<svg><circle cx="1" cy="1" r="1" /></svg>`);
 const fragment = template.content.cloneNode(true);
 
 html`<div>${fragment}</div>`;
-// <div><script>console.log('hello world');</script></div>
-
-html`<div>${fragment}</div>`;
-// Error: Unexpected child element count of zero for given DocumentFragment.
+// <div><svg><circle cx="1" cy="1" r="1"></circle></svg></div>
 ```
 
 ## Supported native tags

--- a/test/test-template-engine.js
+++ b/test/test-template-engine.js
@@ -598,6 +598,12 @@ describe('html rendering', () => {
     render(container, getTemplate({ fragment: template.content.cloneNode(true) }));
     assert(container.childElementCount === 1);
     assert(container.children[0].localName === 'textarea');
+    template.setHTMLUnsafe('');
+    assert(template.content.childNodes.length === 0); // Ensure it’s empty.
+    render(container, getTemplate({ fragment: template.content.cloneNode(true) }));
+    assert(container.childNodes.length === 2); // Only internal cursors exist.
+    assert(container.childNodes[0].nodeType === Node.COMMENT_NODE);
+    assert(container.childNodes[1].nodeType === Node.COMMENT_NODE);
   });
 
   it('renders the same template result multiple times for', () => {
@@ -1109,14 +1115,6 @@ describe('container issues', () => {
 });
 
 describe('value issues', () => {
-  describe('document fragment', () => {
-    it('throws for empty fragment', () => {
-      const callback = () => render(document.createElement('div'), html`<div id="target">${new DocumentFragment()}</div>`);
-      const expectedMessage = 'Unexpected child element count of zero for given DocumentFragment.';
-      assertThrows(callback, expectedMessage);
-    });
-  });
-
   describe('native array', () => {
     it('throws for list with non-template value for array item', () => {
       const callback = () => render(document.createElement('div'), html`

--- a/ts/x-template.d.ts.map
+++ b/ts/x-template.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"x-template.d.ts","sourceRoot":"","sources":["../x-template.js"],"names":[],"mappings":"AAs4BA,yBAA2E;AAC3E,uBAAuE;AAGvE,4BAAiF;AACjF,yBAA2E"}
+{"version":3,"file":"x-template.d.ts","sourceRoot":"","sources":["../x-template.js"],"names":[],"mappings":"AAm4BA,yBAA2E;AAC3E,uBAAuE;AAGvE,4BAAiF;AACjF,yBAA2E"}

--- a/x-template.js
+++ b/x-template.js
@@ -582,9 +582,6 @@ class TemplateEngine {
   // }
 
   static #commitContentFragmentValue(node, startNode, value) {
-    if (value.childElementCount === 0) {
-      throw new Error(`Unexpected child element count of zero for given DocumentFragment.`);
-    }
     const previousSibling = node.previousSibling;
     if (previousSibling !== startNode) {
       TemplateEngine.#removeBetween(startNode, node);


### PR DESCRIPTION
Previously, we had a small developer ergonomics guard to throw if an empty document fragment was bound as content. This commit reverts that prior decision for two reasons:

1. The guard checked for “element” children (not “node” children) as we internally use comment node cursors to annotate our DOM. This was too naive as it also doesn’t detect _text nodes_.
2. The guard was misaligned with our philosophy — we don’t want to teach developers how the browser works. I.e., we expect our users to be experts and so we don’t want to inject special decisions which would infer intent and potentially frustrate expert users.

Closes #310.