### PR TITLE
Use “TemplateEngine” versus “this” in “x-element”.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,3 +84,9 @@ The `/demo` directory contains examples showing different template engines and u
 - Chess piece component
 - Performance comparisons with React, lit-html, uhtml
 - Integration examples for different templating approaches
+
+## Browser and Node Targets
+
+The `x-parser.js` file should be valid in the latest LTS for Node and the latest
+versions of Chrome, Firefox, and Safari. The `x-template.js` and `x-element.js`
+files should be valid in the latest versions of Chrome, Firefox, and Safari.

--- a/x-template.js
+++ b/x-template.js
@@ -142,8 +142,8 @@ class TemplateEngine {
 
   // We only decode things we know to be encoded since it’s non-performant.
   static #decode(encoded) {
-    this.#htmlEntityContainer.setHTMLUnsafe(encoded);
-    const decoded = this.#htmlEntityContainer.content.textContent;
+    TemplateEngine.#htmlEntityContainer.setHTMLUnsafe(encoded);
+    const decoded = TemplateEngine.#htmlEntityContainer.content.textContent;
     return decoded;
   }
 


### PR DESCRIPTION
Minor consistency improvement, we use the class name elsewhere for better predictability with private class methods.