### PR TITLE
Stabilizes performance tests and adds screenshots.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ performance/performance.json
 performance/performance-*.json
 performance/performance-profile.json
 performance/performance-profile-*.json
+performance/performance-screenshot.png
+performance/performance-screenshot-*.png


### PR DESCRIPTION
The performance tests now run in a browser by default (when launched from the command line). Additionally, you can save a screenshot of the result for review.

This is particularly helpful when you want to perform and at-a-glance check on whether a performance change being tested by an AI agent seems to have meaningfully moved the needle or not.