### PR TITLE
Run GitHub test actions on contributor forks.

### DIFF
--- a/.github/workflows/check-branch.yaml
+++ b/.github/workflows/check-branch.yaml
@@ -1,6 +1,0 @@
-# Run tests on pushes to all branches.
-name: Check Branch
-on: [push]
-jobs:
-  test:
-    uses: ./.github/workflows/test.yaml

--- a/.github/workflows/check-main.yaml
+++ b/.github/workflows/check-main.yaml
@@ -1,0 +1,8 @@
+# Run tests on pushes to main branch.
+name: Check Main
+on:
+  push:
+    branches: [main]
+jobs:
+  test:
+    uses: ./.github/workflows/test.yaml

--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -1,0 +1,7 @@
+# Run tests on pull requests, including from forks.
+name: Check Pull Request
+on:
+  pull_request
+jobs:
+  test:
+    uses: ./.github/workflows/test.yaml

--- a/ts/x-template.d.ts.map
+++ b/ts/x-template.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"x-template.d.ts","sourceRoot":"","sources":["../x-template.js"],"names":[],"mappings":"AAm4BA,yBAA2E;AAC3E,uBAAuE;AAGvE,4BAAiF;AACjF,yBAA2E"}
+{"version":3,"file":"x-template.d.ts","sourceRoot":"","sources":["../x-template.js"],"names":[],"mappings":"AA+3BA,yBAA2E;AAC3E,uBAAuE;AAGvE,4BAAiF;AACjF,yBAA2E"}

--- a/x-template.js
+++ b/x-template.js
@@ -808,7 +808,7 @@ class TemplateEngine {
   //   }
   // }
   static #removeWithin(node) {
-    node.replaceChildren()
+    node.replaceChildren();
   }
 
   // TODO: Future state — we may choose to iterate differently as an


### PR DESCRIPTION
Previously, the action in “test.yaml” only ran on branch pushes from maintainers. This was mostly fine, but contributors weren’t getting the same feedback about linting, typing, and testing.

Now, all PRs will cause tests to run. Plus, we continue to specifically target our “main” branch updates as a sanity check.

Closes #324.