### PR TITLE
Use “npm-publish” environment to publish to NPM.

### DIFF
--- a/.github/workflows/publish-to-jsr.yaml
+++ b/.github/workflows/publish-to-jsr.yaml
@@ -4,16 +4,16 @@ on: [workflow_call]
 jobs:
   main:
     runs-on: ubuntu-latest
+    environment: jsr-publish
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22.14'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
       # Can we get this to use “deno publish”?
       # - run: deno publish
       - run: npx jsr publish

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -5,13 +5,13 @@ on: [workflow_call]
 jobs:
   main:
     runs-on: ubuntu-latest
+    environment: npm-publish
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22.14'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
       - run: npm publish
         env:
           # The secrets should be implicitly passed via “secrets: inherit”.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,8 +5,8 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22.14'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
Doing this improves our security as it relates to publishing to NPM from GitHub. These changes relate to #326.

Additionally:
- Stop calling `npm ci` during publish, it’s a known attack vector and we shouldn’t actually need it in our no-build repository.
- Bump GitHub actions dependencies to “@v6”.