### PR TITLE
Disable JSR publishes.

### DIFF
--- a/.github/workflows/publish-to-jsr.yaml
+++ b/.github/workflows/publish-to-jsr.yaml
@@ -4,7 +4,9 @@ on: [workflow_call]
 jobs:
   main:
     runs-on: ubuntu-latest
-    environment: jsr-publish
+    # TODO: Figure out whether an environment is appropriate here. This workflow
+    #  is currently not called by the top-level publish.yaml flow.
+    # environment: jsr-publish
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,8 @@ jobs:
     needs: test
     uses: ./.github/workflows/publish-to-npm.yaml
     secrets: inherit
-  publish-to-jsr:
-    needs: test
-    uses: ./.github/workflows/publish-to-jsr.yaml
-    secrets: inherit
+  # Disabled for now as we sort out “environment” support.
+  # publish-to-jsr:
+  #   needs: test
+  #   uses: ./.github/workflows/publish-to-jsr.yaml
+  #   secrets: inherit


### PR DESCRIPTION
We were only deploying to this registry to help us understand if it is a good fit for the project or not. Currently, JSR is more of a TypeScript-first project and we are a TypeScript-second project (i.e., we use JSDoc to type _actual JavaScript_ and then export `*.d.ts` files from this library). Until they become more lenient on this front, it’s less valuable to us anyhow!