### PR TITLE
Fix duplicate constructor call during analysis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Usage of `globalThis.document` is further limited. Instead, the target
+  document is computed based on a reference node’s `.ownerDocument` property.
+  This future-proofs us a bit more from some potential use-cases we have not yet
+  predicted from developers (#351).
+
+### Fixed
+- Custom element constructors are no longer invoked during template analysis.
+  Previously, the internal computation and caching of a `DocumentFragment` would
+  cause custom element’s constructors to run. Now, an inert document is used at
+  analysis time such that the constructor is only invoked when the element will
+  actually be attached to the DOM (#351).
+
 ## [2.0.0] - 2025-12-13
 
 ### Changed

--- a/test/test-template-engine.js
+++ b/test/test-template-engine.js
@@ -602,6 +602,28 @@ describe('html rendering', () => {
     assert(!!container2.querySelector('#target'));
   });
 
+  // The naming of this test is a little nuanced. Authors expect a custom
+  //  element’s constructor to be called _exactly once_ per new instance of that
+  //  element in the DOM. Previous to this test, constructors were invoked
+  //  during template analysis when we computed a document fragment for later
+  //  use as a clone base.
+  it('does not call custom element constructor during template analysis', () => {
+    let constructorCount = 0;
+    class PhantomTestElement extends HTMLElement {
+      constructor() {
+        super();
+        constructorCount++;
+      }
+    }
+    customElements.define('phantom-test-element', PhantomTestElement);
+
+    const container = document.createElement('div');
+    document.body.append(container);
+    render(container, html`<phantom-test-element></phantom-test-element>`);
+    assert(constructorCount === 1, `Expected 1 constructor call, got ${constructorCount}`);
+    container.remove();
+  });
+
   it('causes single connect / disconnect for re-rendered elements', () => {
     let connects = 0;
     let disconnects = 0;

--- a/types/x-template.d.ts.map
+++ b/types/x-template.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"x-template.d.ts","sourceRoot":"","sources":["../x-template.js"],"names":[],"mappings":"AAiuBA,yBAA2E;AAC3E,uBAAuE"}
+{"version":3,"file":"x-template.d.ts","sourceRoot":"","sources":["../x-template.js"],"names":[],"mappings":"AAquBA,yBAA2E;AAC3E,uBAAuE"}


### PR DESCRIPTION
Previously, we used the global `document` to `createElement` during analysis when the initial fragment is being created. Because the global document has _context_, it can lookup / construct custom elements during analysis.

However, this feels unexpected from a developer perspective that you would get multiple invocations of the constructor “for a single render”. I.e., one for the cached fragment computation, and then one for each actual injection into the connected DOM.

We can fix this by creating an inert, contextless document and using _that_ to create / manage cached fragment computations. Only when you then call `importNode` on this inert fragment to pull it into the _real_ document, does the custom element lookup succeed and the constructor is called, once!

Closes #351.