### PR TITLE
Add a “test” skill to improve agentic workflows.

### DIFF
--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: test
+description: Use when the user asks to run tests, check tests, verify tests
+             pass, or after making code changes that should be validated. Runs
+             unit tests either via CLI (puppeteer) or by visiting a test page
+             in the browser via Chrome DevTools MCP.
+---
+
+# Unit Tests
+
+Tests run in a real browser by loading a document (`test/test-parser.html`).
+Pick the narrowest URL that covers the change.
+
+- All tests: `http://localhost:8080/test/`
+- One test: `http://localhost:8080/test/test-parser.html`
+
+Output is [TAP v14](https://testanything.org/tap-version-14-specification.html).
+Preserve it or summarize plainly ("5/5 passed"). No emojis or checkmarks.
+
+## CLI
+
+Running `npm test` invokes `@netflix/x-test-cli` via `test.sh`.
+See `cd ui && npm test -- --help` for flags (URL, filtering, client). Examples:
+
+```sh
+npm test -- --url=http://localhost:8080/test/test-parser.html
+npm test -- --name-pattern=parser
+```
+
+## MCP (Chrome DevTools)
+
+Use this path to **debug** failures, not just check pass / fail — tests run
+sequentially, each in its own iframe, so you can inspect live DOM, set
+breakpoints, watch network, and evaluate in the failing test’s context. Navigate
+to the test URL. Check the `x-test-reporter` singleton for completion.
+
+```js
+const reporter = document.querySelector('x-test-reporter');
+const done = !reporter.hasAttribute('testing');
+const passed = done && reporter.hasAttribute('ok');
+```
+
+## Writing tests
+
+`@netflix/x-test` mirrors `node:test` + `node:assert/strict` — see its README
+for the API. One x-test-specific constraint: tests must register
+synchronously, so no top-level `await` in test modules. Start async setup as a
+promise at module scope and `await` it inside each `test` callback.


### PR DESCRIPTION
I have used this skill on other projects leveraging “x-test” and it has improved the efficiency of AI collaborations for me. At some point, we could consider documenting a skill like this in “x-test”, but there is some “x-element”-specific stuff in here now, and it feels premature to over-engineer something as simple as a skill.

With this, agents should be able to better interpret conversational requests to test and better-execute iterative workflows which involve both testing via the CLI and via a browser through tools like Chrome DevTools MCP.