### PR TITLE
Update “x-test” / “x-test-cli”.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules
 
+# XTest coverage files
+coverage
+
 # Claude Code local settings
 .claude/*.local.json
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@netflix/eslint-config": "3.0.0",
-        "@netflix/x-test": "2.0.0-rc.6",
-        "@netflix/x-test-cli": "1.0.0-rc.2",
+        "@netflix/x-test": "2.0.0",
+        "@netflix/x-test-cli": "1.0.0",
         "esbuild": "0.27.4",
         "eslint": "10.1.0",
         "eslint-plugin-jsdoc": "62.8.0",
@@ -800,32 +800,41 @@
       }
     },
     "node_modules/@netflix/x-test": {
-      "version": "2.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@netflix/x-test/-/x-test-2.0.0-rc.6.tgz",
-      "integrity": "sha512-/THI7MxmUNS59k4SlvjhG9cVXP8O4RQ18h6yi50rvB7K1MPKGLSy8rDFo8NO+KhLrDUAOqPci6sIaL8tZX0Ctg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@netflix/x-test/-/x-test-2.0.0.tgz",
+      "integrity": "sha512-neZ7UnAusukOVnzNK9kwNVfvQu3Gk7HMWB3aYQ9qBrk2VbTJXXJt42h36cbXSZUO9RRNxOYD95UOzxxq4/kcsw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=20.18",
+        "node": ">=22",
         "npm": ">=10.8"
       }
     },
     "node_modules/@netflix/x-test-cli": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@netflix/x-test-cli/-/x-test-cli-1.0.0-rc.2.tgz",
-      "integrity": "sha512-NFK/CGtLYpqH5JEzkYR784gv0QUnXpiezKxBjYMSMixu/3k7rYdFKpx7mEuAGqUeuibSsyhqMfenYyUPIjCUKg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@netflix/x-test-cli/-/x-test-cli-1.0.0.tgz",
+      "integrity": "sha512-eR5oqmXfOyYgykBKrL3eUKKaajSZNQpEJ5NUbbu/SP6/vvJMuJuzjjX+A2ShDkfbp71FyU9frsKhXIIv4a0pRg==",
       "dev": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "puppeteer": ">=20.0.0",
-        "tap-parser": ">=18.0.0"
-      },
       "bin": {
         "x-test": "x-test-cli.js"
       },
       "engines": {
-        "node": ">=20.18",
+        "node": ">=22",
         "npm": ">=10.8"
+      },
+      "peerDependencies": {
+        "@netflix/x-test": "^2.0.0",
+        "playwright": ">=1.40.0",
+        "puppeteer": ">=22.0.0"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": true
+        },
+        "puppeteer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -1699,16 +1708,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/events-to-array": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-2.0.3.tgz",
-      "integrity": "sha512-f/qE2gImHRa4Cp2y1stEOSgw8wTFyUdVJX7G//bMwbaV9JqISFxg99NbmVQeP7YLnDUZ2un851jlaDrlpmGehQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/events-universal": {
@@ -2678,35 +2677,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tap-parser": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-18.0.0.tgz",
-      "integrity": "sha512-RM3Lp5LNCYcepRqPMuDFg8S3uYV8MDmgxUOjx2Q7f2z5QuB88u92ViBwyp3MuQ/DVMR7v48HrJfV2scXRQYf5A==",
-      "dev": true,
-      "dependencies": {
-        "events-to-array": "^2.0.3",
-        "tap-yaml": "4.0.0"
-      },
-      "bin": {
-        "tap-parser": "bin/cmd.cjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/tap-yaml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-4.0.0.tgz",
-      "integrity": "sha512-CjMbq8hhT5TvzyvHRnzbGp00wmb4TZjSscCRCCJCdCzRb+Pb56HaMlBHNBn1/GZ6UqwUgDKdF18+9VAFnQ4F0g==",
-      "dev": true,
-      "dependencies": {
-        "yaml": "^2.4.1",
-        "yaml-types": "^0.4.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
@@ -2909,31 +2879,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
-      "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==",
-      "dev": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/yaml-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/yaml-types/-/yaml-types-0.4.0.tgz",
-      "integrity": "sha512-XfbA30NUg4/LWUiplMbiufUiwYhgB9jvBhTWel7XQqjV+GaB79c2tROu/8/Tu7jO0HvDvnKWtBk5ksWRrhQ/0g==",
-      "dev": true,
-      "engines": {
-        "node": ">= 16",
-        "npm": ">= 7"
-      },
-      "peerDependencies": {
-        "yaml": "^2.3.0"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build-react": "npm run build-react-demo && npm run build-react-performance",
     "build-react-demo": "esbuild demo/react/index.jsx --bundle --format=esm --jsx=automatic --packages=external --external:../* --outfile=demo/react/index.js",
     "build-react-performance": "esbuild performance/react/index.jsx --bundle --format=esm --jsx=automatic --packages=external --external:../* --outfile=performance/react/index.js",
-    "test": "x-test --client=puppeteer --url=http://127.0.0.1:8080/test/ --coverage=true",
+    "test": "x-test",
     "type": "tsc",
     "performance": "node ./performance.js",
     "bump": "./bump.sh"
@@ -43,14 +43,15 @@
     "/x-element.js",
     "/x-parser.js",
     "/x-template.js",
+    "/x-test.config.js",
     "/demo",
     "/test",
     "/types"
   ],
   "devDependencies": {
     "@netflix/eslint-config": "3.0.0",
-    "@netflix/x-test": "2.0.0-rc.6",
-    "@netflix/x-test-cli": "1.0.0-rc.2",
+    "@netflix/x-test": "2.0.0",
+    "@netflix/x-test-cli": "1.0.0",
     "esbuild": "0.27.4",
     "eslint": "10.1.0",
     "eslint-plugin-jsdoc": "62.8.0",

--- a/test/index.js
+++ b/test/index.js
@@ -1,32 +1,22 @@
-import { test, coverage } from '@netflix/x-test/x-test.js';
+import { load } from '@netflix/x-test/x-test.js';
 
-// We import these here so we can see code coverage.
-import '../x-element.js';
-import '../x-parser.js';
-import '../x-template.js';
-
-// Set a high bar for code coverage!
-coverage(new URL('../x-element.js', import.meta.url).href, 100);
-coverage(new URL('../x-parser.js', import.meta.url).href, 100);
-coverage(new URL('../x-template.js', import.meta.url).href, 100);
-
-test('./test-parser.html');
-test('./test-template-engine.html');
-test('./test-analysis-errors.html');
-test('./test-initialization-errors.html');
-test('./test-attribute-changed-errors.html');
-test('./test-element-upgrade.html');
-test('./test-render.html');
-test('./test-render-root.html');
-test('./test-styles.html');
-test('./test-basic-properties.html');
-test('./test-initial-properties.html');
-test('./test-default-properties.html');
-test('./test-read-only-properties.html');
-test('./test-internal-properties.html');
-test('./test-reflected-properties.html');
-test('./test-computed-properties.html');
-test('./test-observed-properties.html');
-test('./test-listeners.html');
-test('./test-property-deletion.html');
-test('./test-scratch.html');
+load('./test-parser.html');
+load('./test-template-engine.html');
+load('./test-analysis-errors.html');
+load('./test-initialization-errors.html');
+load('./test-attribute-changed-errors.html');
+load('./test-element-upgrade.html');
+load('./test-render.html');
+load('./test-render-root.html');
+load('./test-styles.html');
+load('./test-basic-properties.html');
+load('./test-initial-properties.html');
+load('./test-default-properties.html');
+load('./test-read-only-properties.html');
+load('./test-internal-properties.html');
+load('./test-reflected-properties.html');
+load('./test-computed-properties.html');
+load('./test-observed-properties.html');
+load('./test-listeners.html');
+load('./test-property-deletion.html');
+load('./test-scratch.html');

--- a/test/test-analysis-errors.js
+++ b/test/test-analysis-errors.js
@@ -1,7 +1,7 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
-it('properties should not have hyphens (conflicts with attribute names)', () => {
+test('properties should not have hyphens (conflicts with attribute names)', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -19,7 +19,7 @@ it('properties should not have hyphens (conflicts with attribute names)', () => 
   assert(passed, message);
 });
 
-it('property attributes should not have non-standard casing', () => {
+test('property attributes should not have non-standard casing', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -37,7 +37,7 @@ it('property attributes should not have non-standard casing', () => {
   assert(passed, message);
 });
 
-it('properties should not shadow XElement prototype interface', () => {
+test('properties should not shadow XElement prototype interface', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -55,7 +55,7 @@ it('properties should not shadow XElement prototype interface', () => {
   assert(passed, message);
 });
 
-it('property keys should only be from our known set', () => {
+test('property keys should only be from our known set', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -73,7 +73,7 @@ it('property keys should only be from our known set', () => {
   assert(passed, message);
 });
 
-it('properties should be objects', () => {
+test('properties should be objects', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -91,7 +91,7 @@ it('properties should be objects', () => {
   assert(passed, message);
 });
 
-it('type should be a function', () => {
+test('type should be a function', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -109,7 +109,7 @@ it('type should be a function', () => {
   assert(passed, message);
 });
 
-it('compute should be a function', () => {
+test('compute should be a function', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -127,7 +127,7 @@ it('compute should be a function', () => {
   assert(passed, message);
 });
 
-it('observe should be a function', () => {
+test('observe should be a function', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -145,7 +145,7 @@ it('observe should be a function', () => {
   assert(passed, message);
 });
 
-it('attribute should be a string', () => {
+test('attribute should be a string', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -163,7 +163,7 @@ it('attribute should be a string', () => {
   assert(passed, message);
 });
 
-it('attribute should be a non-empty string', () => {
+test('attribute should be a non-empty string', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -181,7 +181,7 @@ it('attribute should be a non-empty string', () => {
   assert(passed, message);
 });
 
-it('attributes cannot be duplicated (1)', () => {
+test('attributes cannot be duplicated (1)', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -199,7 +199,7 @@ it('attributes cannot be duplicated (1)', () => {
   assert(passed, message);
 });
 
-it('attributes cannot be duplicated (2)', () => {
+test('attributes cannot be duplicated (2)', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -217,7 +217,7 @@ it('attributes cannot be duplicated (2)', () => {
   assert(passed, message);
 });
 
-it('default must be a scalar or a function', () => {
+test('default must be a scalar or a function', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -235,7 +235,7 @@ it('default must be a scalar or a function', () => {
   assert(passed, message);
 });
 
-it('reflect should be a boolean', () => {
+test('reflect should be a boolean', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -253,7 +253,7 @@ it('reflect should be a boolean', () => {
   assert(passed, message);
 });
 
-it('internal should be a boolean', () => {
+test('internal should be a boolean', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -271,7 +271,7 @@ it('internal should be a boolean', () => {
   assert(passed, message);
 });
 
-it('readOnly should be a boolean', () => {
+test('readOnly should be a boolean', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -289,7 +289,7 @@ it('readOnly should be a boolean', () => {
   assert(passed, message);
 });
 
-it('input should be an array', () => {
+test('input should be an array', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -307,7 +307,7 @@ it('input should be an array', () => {
   assert(passed, message);
 });
 
-it('input items should be strings', () => {
+test('input items should be strings', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -325,7 +325,7 @@ it('input items should be strings', () => {
   assert(passed, message);
 });
 
-it('input must be declared as other property names', () => {
+test('input must be declared as other property names', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -346,7 +346,7 @@ it('input must be declared as other property names', () => {
   assert(passed, message);
 });
 
-it('input cannot be cyclic (simple)', () => {
+test('input cannot be cyclic (simple)', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -366,7 +366,7 @@ it('input cannot be cyclic (simple)', () => {
   assert(passed, message);
 });
 
-it('input cannot be cyclic (complex)', () => {
+test('input cannot be cyclic (complex)', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -388,7 +388,7 @@ it('input cannot be cyclic (complex)', () => {
   assert(passed, message);
 });
 
-it('attribute cannot be declared on unserializable types', () => {
+test('attribute cannot be declared on unserializable types', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -406,7 +406,7 @@ it('attribute cannot be declared on unserializable types', () => {
   assert(passed, message);
 });
 
-it('input cannot be declared without a compute callback', () => {
+test('input cannot be declared without a compute callback', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -424,7 +424,7 @@ it('input cannot be declared without a compute callback', () => {
   assert(passed, message);
 });
 
-it('compute cannot be declared without an input callback', () => {
+test('compute cannot be declared without an input callback', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -442,7 +442,7 @@ it('compute cannot be declared without an input callback', () => {
   assert(passed, message);
 });
 
-it('initial cannot be declared for a computed property', () => {
+test('initial cannot be declared for a computed property', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -460,7 +460,7 @@ it('initial cannot be declared for a computed property', () => {
   assert(passed, message);
 });
 
-it('readOnly cannot be declared for a computed property', () => {
+test('readOnly cannot be declared for a computed property', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -478,7 +478,7 @@ it('readOnly cannot be declared for a computed property', () => {
   assert(passed, message);
 });
 
-it('internal properties cannot also be readOnly', () => {
+test('internal properties cannot also be readOnly', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -502,7 +502,7 @@ it('internal properties cannot also be readOnly', () => {
   assert(passed, message);
 });
 
-it('internal properties cannot also be reflected', () => {
+test('internal properties cannot also be reflected', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -526,7 +526,7 @@ it('internal properties cannot also be reflected', () => {
   assert(passed, message);
 });
 
-it('internal properties cannot define an attribute', () => {
+test('internal properties cannot define an attribute', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -550,7 +550,7 @@ it('internal properties cannot define an attribute', () => {
   assert(passed, message);
 });
 
-it('reflected properties must have serializable type', () => {
+test('reflected properties must have serializable type', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -573,7 +573,7 @@ it('reflected properties must have serializable type', () => {
   assert(passed, message);
 });
 
-it('reflected properties must have serializable type (2)', () => {
+test('reflected properties must have serializable type (2)', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {
@@ -595,7 +595,7 @@ it('reflected properties must have serializable type (2)', () => {
   assert(passed, message);
 });
 
-it('listeners as an object should map to functions', () => {
+test('listeners as an object should map to functions', () => {
   let passed = false;
   let message = 'no error was thrown';
   try {

--- a/test/test-attribute-changed-errors.js
+++ b/test/test-attribute-changed-errors.js
@@ -1,7 +1,7 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
-it('errors are thrown in attributeChangedCallback for read-only properties', () => {
+test('errors are thrown in attributeChangedCallback for read-only properties', () => {
   // We cannot try-catch setAttribute, so we fake the attributeChangedCallback.
   class TestElement extends XElement {
     static get properties() {
@@ -28,7 +28,7 @@ it('errors are thrown in attributeChangedCallback for read-only properties', () 
   assert(passed, message);
 });
 
-it('errors are thrown in attributeChangedCallback for computed properties', () => {
+test('errors are thrown in attributeChangedCallback for computed properties', () => {
   // We cannot try-catch setAttribute, so we fake the attributeChangedCallback.
   class TestElement extends XElement {
     static get properties() {

--- a/test/test-basic-properties.js
+++ b/test/test-basic-properties.js
@@ -1,4 +1,4 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
 class TestElement extends XElement {
@@ -49,7 +49,7 @@ class TestElement extends XElement {
 }
 customElements.define('test-element', TestElement);
 
-it('initialization', () => {
+test('initialization', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.shadowRoot.getElementById('normal').textContent === 'Ferus');
@@ -58,19 +58,19 @@ it('initialization', () => {
   assert(el.shadowRoot.getElementById('nul').textContent === '');
 });
 
-it('renders an empty string in place of null value', () => {
+test('renders an empty string in place of null value', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.shadowRoot.getElementById('nul').textContent === '');
 });
 
-it('renders an empty string in place of undefined value', () => {
+test('renders an empty string in place of undefined value', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.shadowRoot.getElementById('undef').textContent === '');
 });
 
-it('property setter updates on next micro tick after connect', async () => {
+test('property setter updates on next micro tick after connect', async () => {
   const el = document.createElement('test-element');
   el.camelCaseProperty = 'Nonconforming';
 
@@ -87,7 +87,7 @@ it('property setter updates on next micro tick after connect', async () => {
   assert(el.shadowRoot.getElementById('camel').textContent === 'Dromedary');
 });
 
-it('property setter renders blank value', async () => {
+test('property setter renders blank value', async () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   el.camelCaseProperty = '';
@@ -102,7 +102,7 @@ it('property setter renders blank value', async () => {
   assert(el.shadowRoot.getElementById('camel').textContent === 'Bactrian');
 });
 
-it('observes all dash-cased versions of public, typeless, serializable, and declared properties', () => {
+test('observes all dash-cased versions of public, typeless, serializable, and declared properties', () => {
   const el = document.createElement('test-element');
   const expected = [
     'normal-property',
@@ -118,7 +118,7 @@ it('observes all dash-cased versions of public, typeless, serializable, and decl
   assert(expected.every(attribute => actual.includes(attribute)));
 });
 
-it('removeAttribute renders blank', async () => {
+test('removeAttribute renders blank', async () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   el.removeAttribute('camel-case-property');
@@ -137,7 +137,7 @@ it('removeAttribute renders blank', async () => {
   assert(el.shadowRoot.getElementById('camel').textContent === '');
 });
 
-it('setAttribute renders the new value', async () => {
+test('setAttribute renders the new value', async () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   el.setAttribute('camel-case-property', 'Racing Camel');
@@ -147,14 +147,14 @@ it('setAttribute renders the new value', async () => {
   assert(el.shadowRoot.getElementById('camel').textContent === 'Racing Camel');
 });
 
-it('coerces attributes to the specified type', () => {
+test('coerces attributes to the specified type', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   el.setAttribute('numeric-property', '-99');
   assert(el.numericProperty === -99);
 });
 
-it('allows properties without types', () => {
+test('allows properties without types', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   for (const value of [{}, 'foo', '5', [], 2]) {
@@ -163,7 +163,7 @@ it('allows properties without types', () => {
   }
 });
 
-it('syncs attributes to properties without types', () => {
+test('syncs attributes to properties without types', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   const value = '123';
@@ -171,14 +171,14 @@ it('syncs attributes to properties without types', () => {
   assert(el.typelessProperty === value);
 });
 
-it('initializes from attributes on connect', () => {
+test('initializes from attributes on connect', () => {
   const el = document.createElement('test-element');
   el.setAttribute('camel-case-property', 'Dromedary');
   document.body.append(el);
   assert(el.camelCaseProperty === 'Dromedary');
 });
 
-it('can use "has" api or "in" operator.', () => {
+test('can use "has" api or "in" operator.', () => {
   class TempTestElement extends XElement {
     static get properties() {
       return {
@@ -199,7 +199,7 @@ it('can use "has" api or "in" operator.', () => {
   customElements.define('temp-test-element-1', TempTestElement);
   const el = new TempTestElement();
   let passed = false;
-  let message;
+  let message = '';
   try {
     el.connectedCallback();
     passed = true;
@@ -209,7 +209,7 @@ it('can use "has" api or "in" operator.', () => {
   assert(passed, message);
 });
 
-it('can use "ownKeys" api.', () => {
+test('can use "ownKeys" api.', () => {
   class TempTestElement extends XElement {
     static get properties() {
       return {
@@ -231,7 +231,7 @@ it('can use "ownKeys" api.', () => {
   customElements.define('temp-test-element-2', TempTestElement);
   const el = new TempTestElement();
   let passed = false;
-  let message;
+  let message = '';
   try {
     el.connectedCallback();
     passed = true;
@@ -241,7 +241,7 @@ it('can use "ownKeys" api.', () => {
   assert(passed, message);
 });
 
-it('can be read', async () => {
+test('can be read', async () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.normalProperty === 'Ferus', 'property was read');
@@ -253,7 +253,7 @@ it('can be read', async () => {
   assert(el.shadowRoot.getElementById('normal').textContent === 'Dromedary');
 });
 
-it('inheritance is considered in type checking', () => {
+test('inheritance is considered in type checking', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   const array = [];
@@ -261,7 +261,7 @@ it('inheritance is considered in type checking', () => {
   assert(el.objectProperty === array, 'property was set');
 });
 
-it('numeric properties deserialize "" (empty) to "NaN"', () => {
+test('numeric properties deserialize "" (empty) to "NaN"', () => {
   const el = document.createElement('test-element');
   el.setAttribute('numeric-property', '0');
   document.body.append(el);
@@ -274,7 +274,7 @@ it('numeric properties deserialize "" (empty) to "NaN"', () => {
   assert(Number.isNaN(el.numericProperty), '"      " was coerced to NaN');
 });
 
-it('cannot set to known properties', () => {
+test('cannot set to known properties', () => {
   class BadTestElement extends XElement {
     static get properties() {
       return {
@@ -304,7 +304,7 @@ it('cannot set to known properties', () => {
   assert(passed, message);
 });
 
-it('cannot set to unknown properties', () => {
+test('cannot set to unknown properties', () => {
   class BadTestElement extends XElement {
     static get properties() {
       return {
@@ -334,7 +334,7 @@ it('cannot set to unknown properties', () => {
   assert(passed, message);
 });
 
-it('cannot get unknown properties', () => {
+test('cannot get unknown properties', () => {
   class BadTestElement extends XElement {
     static get properties() {
       return {
@@ -363,7 +363,7 @@ it('cannot get unknown properties', () => {
   assert(passed, message);
 });
 
-it('cannot set on "internal"', () => {
+test('cannot set on "internal"', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -378,7 +378,7 @@ it('cannot set on "internal"', () => {
   assert(passed, message);
 });
 
-it('cannot "defineProperty" on properties.', () => {
+test('cannot "defineProperty" on properties.', () => {
   class BadTestElement extends XElement {
     static get properties() {
       return {
@@ -408,7 +408,7 @@ it('cannot "defineProperty" on properties.', () => {
   assert(passed, message);
 });
 
-it('cannot "delete" on properties.', () => {
+test('cannot "delete" on properties.', () => {
   class BadTestElement extends XElement {
     static get properties() {
       return {
@@ -438,7 +438,7 @@ it('cannot "delete" on properties.', () => {
   assert(passed, message);
 });
 
-it('cannot "getOwnPropertyDescriptor" on properties.', () => {
+test('cannot "getOwnPropertyDescriptor" on properties.', () => {
   class BadTestElement extends XElement {
     static get properties() {
       return {
@@ -468,7 +468,7 @@ it('cannot "getOwnPropertyDescriptor" on properties.', () => {
   assert(passed, message);
 });
 
-it('cannot "getPrototypeOf" on properties.', () => {
+test('cannot "getPrototypeOf" on properties.', () => {
   class BadTestElement extends XElement {
     static get properties() {
       return {
@@ -498,7 +498,7 @@ it('cannot "getPrototypeOf" on properties.', () => {
   assert(passed, message);
 });
 
-it('cannot "isExtensible" on properties.', () => {
+test('cannot "isExtensible" on properties.', () => {
   class BadTestElement extends XElement {
     static get properties() {
       return {
@@ -528,7 +528,7 @@ it('cannot "isExtensible" on properties.', () => {
   assert(passed, message);
 });
 
-it('cannot "preventExtensions" on properties.', () => {
+test('cannot "preventExtensions" on properties.', () => {
   class BadTestElement extends XElement {
     static get properties() {
       return {
@@ -558,7 +558,7 @@ it('cannot "preventExtensions" on properties.', () => {
   assert(passed, message);
 });
 
-it('cannot "setPrototypeOf" on properties.', () => {
+test('cannot "setPrototypeOf" on properties.', () => {
   class BadTestElement extends XElement {
     static get properties() {
       return {

--- a/test/test-computed-properties.js
+++ b/test/test-computed-properties.js
@@ -1,4 +1,4 @@
-import { it, assert } from '@netflix/x-test/x-test.js';
+import { test, assert } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
 let _count = 0;
@@ -113,7 +113,7 @@ class TestElement extends XElement {
 }
 customElements.define('test-element', TestElement);
 
-it('initializes as expected', () => {
+test('initializes as expected', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.a === undefined);
@@ -126,7 +126,7 @@ it('initializes as expected', () => {
   assert(el.underline === false);
 });
 
-it('properties are recomputed when dependencies change (a, b)', () => {
+test('properties are recomputed when dependencies change (a, b)', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   el.a = 1;
@@ -138,7 +138,7 @@ it('properties are recomputed when dependencies change (a, b)', () => {
   assert(el.underline === true);
 });
 
-it('properties are recomputed when dependencies change (y)', () => {
+test('properties are recomputed when dependencies change (y)', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   el.y = true;
@@ -149,7 +149,7 @@ it('properties are recomputed when dependencies change (y)', () => {
   assert(el.z === false);
 });
 
-it('computed properties can be reflected', async () => {
+test('computed properties can be reflected', async () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   el.a = -1;
@@ -164,7 +164,7 @@ it('computed properties can be reflected', async () => {
   assert(el.hasAttribute('underline'));
 });
 
-it('skips resolution when dependencies are the same', () => {
+test('skips resolution when dependencies are the same', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let count = el.count;
@@ -179,7 +179,7 @@ it('skips resolution when dependencies are the same', () => {
   assert(el.count === ++count);
 });
 
-it('lazily computes', () => {
+test('lazily computes', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let count = el.count;
@@ -206,7 +206,7 @@ it('lazily computes', () => {
   assert(el.count === ++count);
 });
 
-it('does correct NaN checking', () => {
+test('does correct NaN checking', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let count = el.count;
@@ -216,7 +216,7 @@ it('does correct NaN checking', () => {
   assert(el.count === count);
 });
 
-it('resets compute validity on initialization to catch upgrade edge cases with internal, computed properties', () => {
+test('resets compute validity on initialization to catch upgrade edge cases with internal, computed properties', () => {
   const el = document.createElement('test-element');
   el.setAttribute('a', '1');
   el.setAttribute('b', '2');
@@ -229,7 +229,7 @@ it('resets compute validity on initialization to catch upgrade edge cases with i
   assert(el.internal.c === 3);
 });
 
-it('cannot be written to from host', () => {
+test('cannot be written to from host', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -244,7 +244,7 @@ it('cannot be written to from host', () => {
   assert(passed, message);
 });
 
-it('cannot set to known properties', () => {
+test('cannot set to known properties', () => {
   class BadTestElement extends XElement {
     static get properties() {
       return {
@@ -276,7 +276,7 @@ it('cannot set to known properties', () => {
   assert(passed, message);
 });
 
-it('cannot compute a bad value', () => {
+test('cannot compute a bad value', () => {
   class BadTestElement extends XElement {
     static get properties() {
       return {

--- a/test/test-default-properties.js
+++ b/test/test-default-properties.js
@@ -1,4 +1,4 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
 class TestElementBasic extends XElement {
@@ -101,7 +101,7 @@ class TestElementEdge extends XElement {
 }
 customElements.define('test-element-edge', TestElementEdge);
 
-it('basic default properties', async () => {
+test('basic default properties', async () => {
   const el = document.createElement('test-element-basic');
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'one');
@@ -127,41 +127,41 @@ it('basic default properties', async () => {
   assert(el.shadowRoot.textContent === 'one');
 });
 
-it('basic default properties (predefined undefined properties)', () => {
+test('basic default properties (predefined undefined properties)', () => {
   const el = document.createElement('test-element-basic');
   el.one = undefined;
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'one');
 });
 
-it('basic default properties (predefined null properties)', () => {
+test('basic default properties (predefined null properties)', () => {
   const el = document.createElement('test-element-basic');
   el.one = null;
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'one');
 });
 
-it('basic default properties (predefined properties)', () => {
+test('basic default properties (predefined properties)', () => {
   const el = document.createElement('test-element-basic');
   el.one = 'ONE';
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'ONE');
 });
 
-it('basic default properties (predefined attributes)', () => {
+test('basic default properties (predefined attributes)', () => {
   const el = document.createElement('test-element-basic');
   el.setAttribute('one', 'ONE');
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'ONE');
 });
 
-it('anonymous default properties', () => {
+test('anonymous default properties', () => {
   const el = document.createElement('test-element-anonymous');
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'one, two');
 });
 
-it('anonymous default properties (predefined undefined properties)', () => {
+test('anonymous default properties (predefined undefined properties)', () => {
   const el = document.createElement('test-element-anonymous');
   el.one = undefined;
   el.two = undefined;
@@ -169,7 +169,7 @@ it('anonymous default properties (predefined undefined properties)', () => {
   assert(el.shadowRoot.textContent === 'one, two');
 });
 
-it('anonymous default properties (predefined null properties)', () => {
+test('anonymous default properties (predefined null properties)', () => {
   const el = document.createElement('test-element-anonymous');
   el.one = null;
   el.two = null;
@@ -177,7 +177,7 @@ it('anonymous default properties (predefined null properties)', () => {
   assert(el.shadowRoot.textContent === 'one, two');
 });
 
-it('anonymous default properties (predefined properties)', () => {
+test('anonymous default properties (predefined properties)', () => {
   const el = document.createElement('test-element-anonymous');
   el.one = 'ONE';
   el.two = { two: 'TWO' };
@@ -185,20 +185,20 @@ it('anonymous default properties (predefined properties)', () => {
   assert(el.shadowRoot.textContent === 'ONE, TWO');
 });
 
-it('anonymous default properties (predefined attributes)', () => {
+test('anonymous default properties (predefined attributes)', () => {
   const el = document.createElement('test-element-anonymous');
   el.setAttribute('one', 'ONE');
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'ONE, two');
 });
 
-it('initial + default & computed + default properties', () => {
+test('initial + default & computed + default properties', () => {
   const el = document.createElement('test-element-edge');
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'one, two, three');
 });
 
-it('default values from functions are unique per instance', () => {
+test('default values from functions are unique per instance', () => {
   const el1 = document.createElement('test-element-edge');
   const el2 = document.createElement('test-element-edge');
   document.body.append(el1, el2);
@@ -207,7 +207,7 @@ it('default values from functions are unique per instance', () => {
   assert(el1.two !== el2.two);
 });
 
-it('default values from functions persist per instance', async () => {
+test('default values from functions persist per instance', async () => {
   const el = document.createElement('test-element-edge');
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'one, two, three');
@@ -222,7 +222,7 @@ it('default values from functions persist per instance', async () => {
   assert(el.two === defaultTwo);
 });
 
-it('cannot set default to a bad type', () => {
+test('cannot set default to a bad type', () => {
   class BadTestElement extends XElement {
     static get properties() {
       return { bad: { type: String, default: 0 } };

--- a/test/test-element-upgrade.js
+++ b/test/test-element-upgrade.js
@@ -1,4 +1,4 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
 export default class TestElement extends XElement {
@@ -74,7 +74,7 @@ const hasUpgraded = el => {
   );
 };
 
-it('x-element upgrade lifecycle', () => {
+test('x-element upgrade lifecycle', () => {
   const localName = 'test-element';
   assert(
     customElements.get(localName) === undefined,
@@ -141,7 +141,7 @@ it('x-element upgrade lifecycle', () => {
   );
 });
 
-it('preserves x-element properties set before customElements.define', () => {
+test('preserves x-element properties set before customElements.define', () => {
   class PreUpgradeElement extends XElement {
     static get properties() {
       return {

--- a/test/test-initial-properties.js
+++ b/test/test-initial-properties.js
@@ -1,4 +1,4 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
 class TestElementBasic extends XElement {
@@ -95,47 +95,47 @@ class TestElementCompound extends XElement {
 }
 customElements.define('test-element-compound', TestElementCompound);
 
-it('basic initial properties', () => {
+test('basic initial properties', () => {
   const el = document.createElement('test-element-basic');
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'one');
 });
 
-it('basic initial properties (predefined undefined properties)', () => {
+test('basic initial properties (predefined undefined properties)', () => {
   const el = document.createElement('test-element-basic');
   el.one = undefined;
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'one');
 });
 
-it('basic initial properties (predefined null properties)', () => {
+test('basic initial properties (predefined null properties)', () => {
   const el = document.createElement('test-element-basic');
   el.one = null;
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'one');
 });
 
-it('basic initial properties (predefined properties)', () => {
+test('basic initial properties (predefined properties)', () => {
   const el = document.createElement('test-element-basic');
   el.one = 'ONE';
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'ONE');
 });
 
-it('basic initial properties (predefined attributes)', () => {
+test('basic initial properties (predefined attributes)', () => {
   const el = document.createElement('test-element-basic');
   el.setAttribute('one', 'ONE');
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'ONE');
 });
 
-it('anonymous initial properties', () => {
+test('anonymous initial properties', () => {
   const el = document.createElement('test-element-anonymous');
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'one, two');
 });
 
-it('anonymous initial properties (predefined undefined properties)', () => {
+test('anonymous initial properties (predefined undefined properties)', () => {
   const el = document.createElement('test-element-anonymous');
   el.one = undefined;
   el.two = undefined;
@@ -143,7 +143,7 @@ it('anonymous initial properties (predefined undefined properties)', () => {
   assert(el.shadowRoot.textContent === 'one, two');
 });
 
-it('anonymous initial properties (predefined null properties)', () => {
+test('anonymous initial properties (predefined null properties)', () => {
   const el = document.createElement('test-element-anonymous');
   el.one = null;
   el.two = null;
@@ -151,7 +151,7 @@ it('anonymous initial properties (predefined null properties)', () => {
   assert(el.shadowRoot.textContent === 'one, two');
 });
 
-it('anonymous initial properties (predefined properties)', () => {
+test('anonymous initial properties (predefined properties)', () => {
   const el = document.createElement('test-element-anonymous');
   el.one = 'ONE';
   el.two = 'TWO';
@@ -159,7 +159,7 @@ it('anonymous initial properties (predefined properties)', () => {
   assert(el.shadowRoot.textContent === 'ONE, TWO');
 });
 
-it('anonymous initial properties (predefined attributes)', () => {
+test('anonymous initial properties (predefined attributes)', () => {
   const el = document.createElement('test-element-anonymous');
   el.setAttribute('one', 'ONE');
   el.setAttribute('two', 'TWO');
@@ -167,7 +167,7 @@ it('anonymous initial properties (predefined attributes)', () => {
   assert(el.shadowRoot.textContent === 'ONE, TWO');
 });
 
-it('compound initial properties are not shared accross element instances', () => {
+test('compound initial properties are not shared accross element instances', () => {
   const el1 = document.createElement('test-element-compound');
   const el2 = document.createElement('test-element-compound');
   document.body.append(el1, el2);
@@ -176,7 +176,7 @@ it('compound initial properties are not shared accross element instances', () =>
   assert(el1.compound !== el2.compound);
 });
 
-it('cannot set initial to a bad type', () => {
+test('cannot set initial to a bad type', () => {
   class BadTestElement extends XElement {
     static get properties() {
       return { bad: { type: String, initial: 0 } };

--- a/test/test-initialization-errors.js
+++ b/test/test-initialization-errors.js
@@ -1,7 +1,7 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
-it('errors are thrown in connectedCallback for initializing values with bad types', () => {
+test('errors are thrown in connectedCallback for initializing values with bad types', () => {
   // We cannot try-catch append, so we fake the connectedCallback.
   class TestElement extends XElement {
     static get properties() {
@@ -27,7 +27,7 @@ it('errors are thrown in connectedCallback for initializing values with bad type
   assert(passed, message);
 });
 
-it('errors are thrown in connectedCallback for initializing read-only properties', () => {
+test('errors are thrown in connectedCallback for initializing read-only properties', () => {
   // We cannot try-catch append, so we fake the connectedCallback.
   class TestElement extends XElement {
     static get properties() {
@@ -54,7 +54,7 @@ it('errors are thrown in connectedCallback for initializing read-only properties
   assert(passed, message);
 });
 
-it('errors are thrown in connectedCallback for initializing computed properties', () => {
+test('errors are thrown in connectedCallback for initializing computed properties', () => {
   // We cannot try-catch append, so we fake the connectedCallback.
   class TestElement extends XElement {
     static get properties() {
@@ -84,7 +84,7 @@ it('errors are thrown in connectedCallback for initializing computed properties'
 
 // Depending on the browser — the underlying error is surfaced differently.
 // We just match our custom suffix to be agnostic.
-it('errors are thrown in connectedCallback when template result fails to render', () => {
+test('errors are thrown in connectedCallback when template result fails to render', () => {
   // We cannot try-catch append, so we fake the connectedCallback.
   class TestElement extends XElement {
     static get properties() {
@@ -115,7 +115,7 @@ it('errors are thrown in connectedCallback when template result fails to render'
 
 // Depending on the browser — the underlying error is surfaced differently.
 // We just match our custom suffix to be agnostic.
-it('errors are thrown in connectedCallback when template result fails to render (with ids, classes, and attributes)', () => {
+test('errors are thrown in connectedCallback when template result fails to render (with ids, classes, and attributes)', () => {
   // We cannot try-catch append, so we fake the connectedCallback.
   class TestElement extends XElement {
     static get properties() {

--- a/test/test-internal-properties.js
+++ b/test/test-internal-properties.js
@@ -1,4 +1,4 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
 class TestElement extends XElement {
@@ -32,19 +32,19 @@ class TestElement extends XElement {
 }
 customElements.define('test-element', TestElement);
 
-it('initialization', () => {
+test('initialization', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'Ferus', 'initialized as expected');
 });
 
-it('can use "has" api or "in" operator.', () => {
+test('can use "has" api or "in" operator.', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert('internalProperty' in el.internal, 'The "has" trap does not work.');
 });
 
-it('can use "ownKeys" api.', () => {
+test('can use "ownKeys" api.', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   const ownKeys = Reflect.ownKeys(el.internal);
@@ -57,14 +57,14 @@ it('can use "ownKeys" api.', () => {
   );
 });
 
-it('cannot be read on host', () => {
+test('cannot be read on host', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.internal.internalProperty === 'Ferus');
   assert(el.internalProperty === undefined);
 });
 
-it('cannot be written to on host', () => {
+test('cannot be written to on host', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.internal.internalProperty === 'Ferus');
@@ -74,13 +74,13 @@ it('cannot be written to on host', () => {
   assert(el.internalProperty === 'ignored');
 });
 
-it('can be read from "internal"', () => {
+test('can be read from "internal"', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.internal.internalProperty === 'Ferus');
 });
 
-it('can be written to from "internal"', async () => {
+test('can be written to from "internal"', async () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   el.internal.internalProperty = 'Dromedary';
@@ -90,7 +90,7 @@ it('can be written to from "internal"', async () => {
   assert(el.shadowRoot.textContent === 'Dromedary', 'written to as expected');
 });
 
-it('cannot be written to from "internal" if computed', () => {
+test('cannot be written to from "internal" if computed', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -105,7 +105,7 @@ it('cannot be written to from "internal" if computed', () => {
   assert(passed, message);
 });
 
-it('cannot set to known properties', () => {
+test('cannot set to known properties', () => {
   class BadTestElement extends XElement {
     static get properties() {
       return {
@@ -136,7 +136,7 @@ it('cannot set to known properties', () => {
   assert(passed, message);
 });
 
-it('cannot get unknown properties', () => {
+test('cannot get unknown properties', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -151,7 +151,7 @@ it('cannot get unknown properties', () => {
   assert(passed, message);
 });
 
-it('cannot get unknown properties', () => {
+test('cannot get unknown properties', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -166,7 +166,7 @@ it('cannot get unknown properties', () => {
   assert(passed, message);
 });
 
-it('cannot "defineProperty" on internal.', () => {
+test('cannot "defineProperty" on internal.', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -184,7 +184,7 @@ it('cannot "defineProperty" on internal.', () => {
 // This is a funny one, you can set to undefined, but we strictly don't let you
 // "delete" since it has a different meaning and you strictly cannot delete our
 // accessors.
-it('cannot "delete" on internal.', () => {
+test('cannot "delete" on internal.', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -199,7 +199,7 @@ it('cannot "delete" on internal.', () => {
   assert(passed, message);
 });
 
-it('cannot "getOwnPropertyDescriptor" on internal.', () => {
+test('cannot "getOwnPropertyDescriptor" on internal.', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -214,7 +214,7 @@ it('cannot "getOwnPropertyDescriptor" on internal.', () => {
   assert(passed, message);
 });
 
-it('cannot "getPrototypeOf" on internal.', () => {
+test('cannot "getPrototypeOf" on internal.', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -229,7 +229,7 @@ it('cannot "getPrototypeOf" on internal.', () => {
   assert(passed, message);
 });
 
-it('cannot "isExtensible" on internal.', () => {
+test('cannot "isExtensible" on internal.', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -244,7 +244,7 @@ it('cannot "isExtensible" on internal.', () => {
   assert(passed, message);
 });
 
-it('cannot "preventExtensions" on internal.', () => {
+test('cannot "preventExtensions" on internal.', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -259,7 +259,7 @@ it('cannot "preventExtensions" on internal.', () => {
   assert(passed, message);
 });
 
-it('cannot "setPrototypeOf" on internal.', () => {
+test('cannot "setPrototypeOf" on internal.', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;

--- a/test/test-listeners.js
+++ b/test/test-listeners.js
@@ -1,4 +1,4 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
 class TestElementChild extends HTMLElement {
@@ -83,7 +83,7 @@ class TestElement extends XElement {
 }
 customElements.define('test-element', TestElement);
 
-it('test lifecycle', () => {
+test('test lifecycle', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.clicks === 0 && el.count === 0, 'initialized as expected');
@@ -106,7 +106,7 @@ it('test lifecycle', () => {
   assert(el.clicks === 3 && el.count === 1, 'adds back listeners on reconnect');
 });
 
-it('test connectedCallback lifecycle', () => {
+test('test connectedCallback lifecycle', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   const eventEmitter = el.shadowRoot.getElementById('custom-event-emitter');
@@ -122,7 +122,7 @@ it('test connectedCallback lifecycle', () => {
   assert(el.customEventCount === 2);
 });
 
-it('test manual lifecycle', () => {
+test('test manual lifecycle', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let count = 0;
@@ -136,7 +136,7 @@ it('test manual lifecycle', () => {
   assert(count === 2, 'listener was removed');
 });
 
-it('test synchronous event handling', () => {
+test('test synchronous event handling', () => {
   // This is subtle, but it tests that if child elements emit events
   //  synchronously in their first render, delegated event listening from the
   //  parent will still work.
@@ -149,7 +149,7 @@ it('test synchronous event handling', () => {
   assert(el.connections === count);
 });
 
-it('throws for bad element on listen', () => {
+test('throws for bad element on listen', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -164,7 +164,7 @@ it('throws for bad element on listen', () => {
   assert(passed, message);
 });
 
-it('throws for bad type on listen', () => {
+test('throws for bad type on listen', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -179,7 +179,7 @@ it('throws for bad type on listen', () => {
   assert(passed, message);
 });
 
-it('throws for bad callback on listen', () => {
+test('throws for bad callback on listen', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -194,7 +194,7 @@ it('throws for bad callback on listen', () => {
   assert(passed, message);
 });
 
-it('throws for bad options on listen', () => {
+test('throws for bad options on listen', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -209,7 +209,7 @@ it('throws for bad options on listen', () => {
   assert(passed, message);
 });
 
-it('throws for bad element on unlisten', () => {
+test('throws for bad element on unlisten', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -224,7 +224,7 @@ it('throws for bad element on unlisten', () => {
   assert(passed, message);
 });
 
-it('throws for bad type on unlisten', () => {
+test('throws for bad type on unlisten', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -239,7 +239,7 @@ it('throws for bad type on unlisten', () => {
   assert(passed, message);
 });
 
-it('throws for bad callback on unlisten', () => {
+test('throws for bad callback on unlisten', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -254,7 +254,7 @@ it('throws for bad callback on unlisten', () => {
   assert(passed, message);
 });
 
-it('throws for bad options on unlisten', () => {
+test('throws for bad options on unlisten', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;

--- a/test/test-observed-properties.js
+++ b/test/test-observed-properties.js
@@ -1,4 +1,4 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
 class TestElement extends XElement {
@@ -101,77 +101,51 @@ class TestElement extends XElement {
 
 customElements.define('test-element', TestElement);
 
-
-const isObject = obj => obj instanceof Object && obj !== null;
-const deepEqual = (a, b) => {
-  if (a === b) {
-    return true;
-  }
-  return (
-    isObject(a) &&
-    isObject(b) &&
-    // Note, we ignore non-enumerable properties (Symbols) here.
-    Object.keys(a).length === Object.keys(b).length &&
-    Object.keys(a).every(key => deepEqual(a[key], b[key]))
-  );
-};
-
-it('initialized as expected', () => {
+test('initialized as expected', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
-  assert(
-    deepEqual(el.changes, [
-      { property: 'c', value: 'undefined undefined', oldValue: undefined },
-    ]),
-    'initialized as expected'
-  );
+
+  assert.deepEqual(el.changes, [
+    { property: 'c', value: 'undefined undefined', oldValue: undefined },
+  ], 'initialized as expected');
   document.body.removeChild(el);
 });
 
-it('x-element observed properties', async () => {
+test('x-element observed properties', async () => {
   const el = document.createElement('test-element');
   el.a = '11';
   el.b = '22';
   document.body.append(el);
 
-  assert(
-    deepEqual(el.changes, [
-      { property: 'a', value: '11', oldValue: undefined },
-      { property: 'b', value: '22', oldValue: undefined },
-      { property: 'c', value: '11 22', oldValue: undefined },
-    ]),
-    'initialized as expected'
-  );
+  assert.deepEqual(el.changes, [
+    { property: 'a', value: '11', oldValue: undefined },
+    { property: 'b', value: '22', oldValue: undefined },
+    { property: 'c', value: '11 22', oldValue: undefined },
+  ], 'initialized as expected');
 
   el.b = 'hey';
 
   // We must await a microtask for the update to take place.
   await Promise.resolve();
-  assert(
-    deepEqual(el.changes, [
-      { property: 'a', value: '11', oldValue: undefined },
-      { property: 'b', value: '22', oldValue: undefined },
-      { property: 'c', value: '11 22', oldValue: undefined },
-      { property: 'c', value: '11 hey', oldValue: '11 22' },
-      { property: 'b', value: 'hey', oldValue: '22' },
-    ]),
-    'observe callbacks are called when properties change'
-  );
+  assert.deepEqual(el.changes, [
+    { property: 'a', value: '11', oldValue: undefined },
+    { property: 'b', value: '22', oldValue: undefined },
+    { property: 'c', value: '11 22', oldValue: undefined },
+    { property: 'c', value: '11 hey', oldValue: '11 22' },
+    { property: 'b', value: 'hey', oldValue: '22' },
+  ], 'observe callbacks are called when properties change');
 
   el.b = 'hey';
 
   // We must await a microtask for the update to take place.
   await Promise.resolve();
-  assert(
-    deepEqual(el.changes, [
-      { property: 'a', value: '11', oldValue: undefined },
-      { property: 'b', value: '22', oldValue: undefined },
-      { property: 'c', value: '11 22', oldValue: undefined },
-      { property: 'c', value: '11 hey', oldValue: '11 22' },
-      { property: 'b', value: 'hey', oldValue: '22' },
-    ]),
-    'observe callbacks are not called when set property is the same'
-  );
+  assert.deepEqual(el.changes, [
+    { property: 'a', value: '11', oldValue: undefined },
+    { property: 'b', value: '22', oldValue: undefined },
+    { property: 'c', value: '11 22', oldValue: undefined },
+    { property: 'c', value: '11 hey', oldValue: '11 22' },
+    { property: 'b', value: 'hey', oldValue: '22' },
+  ], 'observe callbacks are not called when set property is the same');
 
   el.popped = true;
 
@@ -181,20 +155,17 @@ it('x-element observed properties', async () => {
 
   // We must await a microtask for the update to take place.
   await Promise.resolve();
-  assert(
-    deepEqual(el.changes, [
-      { property: 'a', value: '11', oldValue: undefined },
-      { property: 'b', value: '22', oldValue: undefined },
-      { property: 'c', value: '11 22', oldValue: undefined },
-      { property: 'c', value: '11 hey', oldValue: '11 22' },
-      { property: 'b', value: 'hey', oldValue: '22' },
-      { property: 'popped', value: true, oldValue: undefined },
-    ]),
-    'no re-entrance for observed, reflected properties'
-  );
+  assert.deepEqual(el.changes, [
+    { property: 'a', value: '11', oldValue: undefined },
+    { property: 'b', value: '22', oldValue: undefined },
+    { property: 'c', value: '11 22', oldValue: undefined },
+    { property: 'c', value: '11 hey', oldValue: '11 22' },
+    { property: 'b', value: 'hey', oldValue: '22' },
+    { property: 'popped', value: true, oldValue: undefined },
+  ], 'no re-entrance for observed, reflected properties');
 });
 
-it('child properties are bound before initialization', () => {
+test('child properties are bound before initialization', () => {
   const observations = [];
   class TestInner extends XElement {
     static get properties() {
@@ -224,7 +195,7 @@ it('child properties are bound before initialization', () => {
   customElements.define('test-outer', TestOuter);
   const el = document.createElement('test-outer');
   document.body.append(el);
-  assert(observations[0] === true, observations[0]);
-  assert(observations.length === 1, observations);
+  assert(observations[0] === true, JSON.stringify(observations[0], null, 2));
+  assert(observations.length === 1, JSON.stringify(observations, null, 2));
   el.remove();
 });

--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -1,4 +1,4 @@
-import { assert, describe, it } from '@netflix/x-test/x-test.js';
+import { assert, suite, test } from '@netflix/x-test/x-test.js';
 import { XParser } from '../x-parser.js';
 
 // Special symbol to hang test information off of.
@@ -56,37 +56,6 @@ const stringifyTokens = tokens => {
   return `[\n${lines.join('\n')}\n]`;
 };
 
-// Helper for figuring out if the tokens we got were correct.
-const isObject = obj => obj instanceof Object && obj !== null;
-const deepEqual = (a, b) => {
-  if (a === b) {
-    return true;
-  }
-  return (
-    isObject(a) &&
-    isObject(b) &&
-    // Note, we ignore non-enumerable properties (Symbols) here.
-    Object.keys(a).length === Object.keys(b).length &&
-    Object.keys(a).every(key => deepEqual(a[key], b[key]))
-  );
-};
-
-// Simple helper for asserting thrown messages.
-const assertThrows = (callback, expectedMessage, options) => {
-  let thrown = false;
-  try {
-    callback();
-  } catch (error) {
-    thrown = true;
-    if (options?.startsWith === true) {
-      assert(error.message.startsWith(expectedMessage), error.message);
-    } else {
-      assert(error.message === expectedMessage, error.message);
-    }
-  }
-  assert(thrown, 'no error was thrown');
-};
-
 // Simpler helper to add some test information under a TEST symbol.
 const wrapper = strings => {
   const tokens = [];
@@ -107,14 +76,14 @@ const html = strings => wrapper(strings);
 //  from choking when trying to highlight, we also have a “htmlol” function.
 const htmlol = strings => wrapper(strings);
 
-describe('basic', () => {
-  it('empty template works', () => {
+suite('basic', () => {
+  test('empty template works', () => {
     const expectedTokens = [];
     const tokens = html``;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('single string works', () => {
+  test('single string works', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 4, substring: 'div' },
@@ -127,10 +96,10 @@ describe('basic', () => {
       { type: 'end-tag-close', index: 0, start: 27, end: 28, substring: '>' },
     ];
     const tokens = html`<div>No interpolation.</div>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('multi-line string works', () => {
+  test('multi-line string works', () => {
     const expectedTokens = [
       { type: 'text-start', index: 0, start: 0, end: 0, substring: '' },
       { type: 'text-plaintext', index: 0, start: 0, end: 37, substring: '\n      one\n      two\n      three\n    ' },
@@ -141,22 +110,22 @@ describe('basic', () => {
       two
       three
     `;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 });
 
-describe('comments', () => {
-  it('comments work', () => {
+suite('comments', () => {
+  test('comments work', () => {
     const expectedTokens = [
       { type: 'comment-open', index: 0, start: 0, end: 4, substring: '<!--' },
       { type: 'comment', index: 0, start: 4, end: 6, substring: 'hi' },
       { type: 'comment-close', index: 0, start: 6, end: 9, substring: '-->' },
     ];
     const tokens = html`<!--hi-->`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('multi-line comments work', () => {
+  test('multi-line comments work', () => {
     const expectedTokens = [
       { type: 'comment-open', index: 0, start: 0, end: 4, substring: '<!--' },
       { type: 'comment', index: 0, start: 4, end: 22, substring: '\n        hi\n      ' },
@@ -165,12 +134,12 @@ describe('comments', () => {
     const tokens = html`<!--
         hi
       -->`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 });
 
-describe('character references', () => {
-  it('accepts references in replaceable character data', () => {
+suite('character references', () => {
+  test('accepts references in replaceable character data', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 4, substring: 'div' },
@@ -192,10 +161,10 @@ describe('character references', () => {
       { type: 'end-tag-close', index: 0, start: 55, end: 56, substring: '>' },
     ];
     const tokens = html`<div>&#123;--&lt;&amp;--&gt;&apos;&quot;--&#x007D;</div>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('accepts references in replaceable character data for special syntax', () => {
+  test('accepts references in replaceable character data for special syntax', () => {
     const expectedTokens = [
       { type: 'text-start', index: 0, start: 0, end: 0, substring: '' },
       { type: 'text-reference', index: 0, start: 0, end: 5, substring: '&amp;' },
@@ -206,10 +175,10 @@ describe('character references', () => {
       { type: 'text-end', index: 0, start: 25, end: 25, substring: '' },
     ];
     const tokens = html`&amp;&lt;&gt;&quot;&apos;`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('accepts references for commonly-used characters', () => {
+  test('accepts references for commonly-used characters', () => {
     const expectedTokens = [
       { type: 'text-start', index: 0, start: 0, end: 0, substring: '' },
       { type: 'text-reference', index: 0, start: 0, end: 6, substring: '&nbsp;' },
@@ -226,10 +195,10 @@ describe('character references', () => {
       { type: 'text-end', index: 0, start: 78, end: 78, substring: '' },
     ];
     const tokens = html`&nbsp;&lsquo;&rsquo;&ldquo;&rdquo;&ndash;&mdash;&hellip;&bull;&middot;&dagger;`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('accepts references in attribute values', () => {
+  test('accepts references in attribute values', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 4, substring: 'div' },
@@ -255,10 +224,10 @@ describe('character references', () => {
       { type: 'end-tag-close', index: 0, start: 60, end: 61, substring: '>' },
     ];
     const tokens = html`<div foo="--&#123;&lt;&amp;&gt;&apos;&quot;&#x007D;--"></div>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('accepts named references which require surrogate pairs', () => {
+  test('accepts named references which require surrogate pairs', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 4, substring: 'div' },
@@ -276,10 +245,10 @@ describe('character references', () => {
       { type: 'end-tag-close', index: 0, start: 34, end: 35, substring: '>' },
     ];
     const tokens = html`<div>--&bopf;&bopf;--&bopf;--</div>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('leaves malformed references as-is', () => {
+  test('leaves malformed references as-is', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 4, substring: 'div' },
@@ -294,12 +263,12 @@ describe('character references', () => {
       { type: 'end-tag-close', index: 0, start: 19, end: 20, substring: '>' },
     ];
     const tokens = htmlol`<div>--&:^);--</div>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 });
 
-describe('JS-y escapes / encodings', () => {
-  it('properly encoded JS escape characters work', () => {
+suite('JS-y escapes / encodings', () => {
+  test('properly encoded JS escape characters work', () => {
     // Just checks that no errors are thrown.
     html`
       The &bsol;n is a newline.
@@ -318,8 +287,8 @@ describe('JS-y escapes / encodings', () => {
   });
 });
 
-describe('attributes and properties', () => {
-  it('unbound attributes are reported', () => {
+suite('attributes and properties', () => {
+  test('unbound attributes are reported', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 4, substring: 'div' },
@@ -337,10 +306,10 @@ describe('attributes and properties', () => {
       { type: 'end-tag-close', index: 0, start: 16, end: 17, substring: '>' },
     ];
     const tokens = html`<div f="b"></div>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('bound attributes are reported', () => {
+  test('bound attributes are reported', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 4, substring: 'div' },
@@ -356,12 +325,12 @@ describe('attributes and properties', () => {
       { type: 'end-tag-close', index: 1, start: 7, end: 8, substring: '>' },
     ];
     const tokens = html`<div attr="${VALUE}"></div>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
   // It’s also a good test that this is at the _end_ of the opening tag. If we
   //  change this, we should write another test to separately check that.
-  it('unbound boolean attributes are reported', () => {
+  test('unbound boolean attributes are reported', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 4, substring: 'div' },
@@ -373,10 +342,10 @@ describe('attributes and properties', () => {
       { type: 'end-tag-close', index: 0, start: 14, end: 15, substring: '>' },
     ];
     const tokens = html`<div foo></div>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('bound boolean attributes are reported', () => {
+  test('bound boolean attributes are reported', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 4, substring: 'div' },
@@ -393,10 +362,10 @@ describe('attributes and properties', () => {
       { type: 'end-tag-close', index: 1, start: 7, end: 8, substring: '>' },
     ];
     const tokens = html`<div ?foo="${VALUE}"></div>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('bound defined attributes are reported', () => {
+  test('bound defined attributes are reported', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 4, substring: 'div' },
@@ -413,10 +382,10 @@ describe('attributes and properties', () => {
       { type: 'end-tag-close', index: 1, start: 7, end: 8, substring: '>' },
     ];
     const tokens = html`<div ??foo="${VALUE}"></div>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('unbound “on*” attributes as event handlers work', () => {
+  test('unbound “on*” attributes as event handlers work', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 4, substring: 'div' },
@@ -438,10 +407,10 @@ describe('attributes and properties', () => {
       { type: 'end-tag-close', index: 0, start: 64, end: 65, substring: '>' },
     ];
     const tokens = html`<div onclick="this.textContent = '&hellip;hi&bsol;u2026';"></div>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('properties are reported', () => {
+  test('properties are reported', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 4, substring: 'div' },
@@ -458,31 +427,31 @@ describe('attributes and properties', () => {
       { type: 'end-tag-close', index: 1, start: 7, end: 8, substring: '>' },
     ];
     const tokens = html`<div .prop="${VALUE}"></div>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 });
 
-describe('content interpolation', () => {
-  it('solo interpolation works', () => {
+suite('content interpolation', () => {
+  test('solo interpolation works', () => {
     const expectedTokens = [
       { type: 'bound-content-value', index: 0, start: 0, end: 0, substring: '' },
     ];
     const tokens = html`${VALUE}`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('adjacent interpolations work', () => {
+  test('adjacent interpolations work', () => {
     const expectedTokens = [
       { type: 'bound-content-value', index: 0, start: 0, end: 0, substring: '' },
       { type: 'bound-content-value', index: 1, start: 0, end: 0, substring: '' },
     ];
     const tokens = html`${VALUE}${VALUE}`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 });
 
-describe('odds and ends', () => {
-  it('surprisingly-accepted characters work', () => {
+suite('odds and ends', () => {
+  test('surprisingly-accepted characters work', () => {
     const expectedTokens = [
       { type: 'text-start', index: 0, start: 0, end: 0, substring: '' },
       { type: 'text-plaintext', index: 0, start: 0, end: 9, substring: '>\'"&& & &' },
@@ -498,10 +467,10 @@ describe('odds and ends', () => {
       { type: 'text-end', index: 0, start: 21, end: 21, substring: '' },
     ];
     const tokens = html`>'"&& & &<div></div>&`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('elements with "/" characters in attributes work', () => {
+  test('elements with "/" characters in attributes work', () => {
     const expectedTokens = [
       { type: 'text-start', index: 0, start: 0, end: 0, substring: '' },
       { type: 'text-plaintext', index: 0, start: 0, end: 7, substring: '\n      ' },
@@ -534,10 +503,10 @@ describe('odds and ends', () => {
         click me
       </a>
     `;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('elements with "<" or ">" characters in attributes work', () => {
+  test('elements with "<" or ">" characters in attributes work', () => {
     const expectedTokens = [
       { type: 'text-start', index: 0, start: 0, end: 0, substring: '' },
       { type: 'text-plaintext', index: 0, start: 0, end: 7, substring: '\n      ' },
@@ -579,10 +548,10 @@ describe('odds and ends', () => {
         click me
       </a>
     `;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('multiple opening and closing tags work', () => {
+  test('multiple opening and closing tags work', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 4, substring: 'div' },
@@ -598,10 +567,10 @@ describe('odds and ends', () => {
       { type: 'end-tag-close', index: 0, start: 21, end: 22, substring: '>' },
     ];
     const tokens = html`<div><div></div></div>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('void elements work', () => {
+  test('void elements work', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 6, substring: 'input' },
@@ -622,10 +591,10 @@ describe('odds and ends', () => {
       { type: 'void-tag-close', index: 1, start: 1, end: 2, substring: '>' },
     ];
     const tokens = html`<input type="checkbox" value="${VALUE}">`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('textarea elements work', () => {
+  test('textarea elements work', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 9, substring: 'textarea' },
@@ -642,10 +611,10 @@ describe('odds and ends', () => {
       { type: 'end-tag-close', index: 0, start: 68, end: 69, substring: '>' },
     ];
     const tokens = html`<textarea><em>this</em> is the &ldquo;default&rdquo; value</textarea>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('textarea elements with strict interpolation work', () => {
+  test('textarea elements with strict interpolation work', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 9, substring: 'textarea' },
@@ -656,10 +625,10 @@ describe('odds and ends', () => {
       { type: 'end-tag-close', index: 1, start: 10, end: 11, substring: '>' },
     ];
     const tokens = html`<textarea>${VALUE}</textarea>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('custom elements work', () => {
+  test('custom elements work', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 8, substring: 'foo-bar' },
@@ -669,10 +638,10 @@ describe('odds and ends', () => {
       { type: 'end-tag-close', index: 0, start: 18, end: 19, substring: '>' },
     ];
     const tokens = html`<foo-bar></foo-bar>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 
-  it('template elements work', () => {
+  test('template elements work', () => {
     const expectedTokens = [
       { type: 'start-tag-open', index: 0, start: 0, end: 1, substring: '<' },
       { type: 'start-tag-name', index: 0, start: 1, end: 9, substring: 'template' },
@@ -694,78 +663,78 @@ describe('odds and ends', () => {
       { type: 'end-tag-close', index: 0, start: 38, end: 39, substring: '>' },
     ];
     const tokens = html`<template><div><p></p></div></template>`;
-    assert(deepEqual(tokens, expectedTokens), stringifyTokens(tokens));
+    assert.deepEqual([...tokens], expectedTokens, stringifyTokens(tokens));
   });
 });
 
-describe('errors', () => {
-  it('throws when markup after end tag cannot be parsed', () => {
+suite('errors', () => {
+  test('throws when markup after end tag cannot be parsed', () => {
     const callback = () => htmlol`<div></div><`;
-    const expectedMessage = '[#110]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#110]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when attempting non-trivial interpolation of a textarea tag (preceding space)', () => {
+  test('throws when attempting non-trivial interpolation of a textarea tag (preceding space)', () => {
     const callback = () => html`<textarea id="target"> ${VALUE}</textarea>`;
-    const expectedMessage = '[#155]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#155]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when attempting non-trivial interpolation of a textarea tag (succeeding space)', () => {
+  test('throws when attempting non-trivial interpolation of a textarea tag (succeeding space)', () => {
     const callback = () => html`<textarea id="target">${VALUE} </textarea>`;
-    const expectedMessage = '[#155]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#155]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when attempting non-trivial interpolation of a textarea tag', () => {
+  test('throws when attempting non-trivial interpolation of a textarea tag', () => {
     const callback = () => html`<textarea id="target">please ${VALUE} no</textarea>`;
-    const expectedMessage = '[#155]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#155]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when attempting non-trivial interpolation of a textarea tag via nesting', () => {
+  test('throws when attempting non-trivial interpolation of a textarea tag via nesting', () => {
     const callback = () => html`<textarea id="target"><b>please ${VALUE} no</b></textarea>`;
-    const expectedMessage = '[#155]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#155]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when attempting non-trivial interpolation of a textarea tag via nesting', () => {
+  test('throws when attempting non-trivial interpolation of a textarea tag via nesting', () => {
     const callback = () => html`<textarea><b>please ${VALUE} no</b></textarea>`;
-    const expectedMessage = '[#155]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#155]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when interpolation of a textarea is at the end of the template', () => {
+  test('throws when interpolation of a textarea is at the end of the template', () => {
     const callback = () => html`<textarea>${VALUE}`;
-    const expectedMessage = '[#155]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#155]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for unquoted attributes', () => {
+  test('throws for unquoted attributes', () => {
     const callback = () => html`<div id="target" not-ok=${VALUE}>Gotta double-quote those.</div>`;
-    const expectedMessage = '[#125]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#125]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for single-quoted attributes', () => {
+  test('throws for single-quoted attributes', () => {
     const callback = () => html`<div id="target" not-ok='${VALUE}'>Gotta double-quote those.</div>`;
-    const expectedMessage = '[#125]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#125]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for unquoted properties', () => {
+  test('throws for unquoted properties', () => {
     const callback = () => html`<div id="target" .notOk=${VALUE}>Gotta double-quote those.</div>`;
-    const expectedMessage = '[#126]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#126]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for single-quoted properties', () => {
+  test('throws for single-quoted properties', () => {
     const callback = () => html`<div id="target" .notOk='${VALUE}'>Gotta double-quote those.</div>`;
-    const expectedMessage = '[#126]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#126]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('no weird re-entrance issues', async () => {
+  test('no weird re-entrance issues', async () => {
     class TestElement1 extends HTMLElement {
       constructor() {
         super();
@@ -787,17 +756,17 @@ describe('errors', () => {
     document.createElement('test-element-2');
   });
 
-  it('throws every time if there is a parsing error', () => {
+  test('throws every time if there is a parsing error', () => {
     // At one point, we only threw the _first_ time we encountered a given
     //  tagged template function “strings” array. We want to throw always.
     const callback = () => html`<-div></-div>`;
-    const expectedMessage = '[#120]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
-    assertThrows(callback, expectedMessage, { startsWith: true });
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#120]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws correct message for complex template', () => {
+  test('throws correct message for complex template', () => {
     // Just creating a more complex test to make sure nothing is missed. Many
     //  of the other tests have errors within the first string of the “strings”
     //  array, for example.
@@ -807,96 +776,96 @@ describe('errors', () => {
         <span id="name" _foo>${VALUE}</span>
       </div>
     `;
-    const expectedMessage = '[#124]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#124]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when unbound content is followed by malformed html', () => {
+  test('throws when unbound content is followed by malformed html', () => {
     const callback = () => html`hi <-div>`;
-    const expectedMessage = '[#120]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#120]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when an unbound comment is followed by malformed html', () => {
+  test('throws when an unbound comment is followed by malformed html', () => {
     const callback = () => html`<!--hi--><-div>`;
-    const expectedMessage = '[#120]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#120]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if open tag starts with a hyphen', () => {
+  test('throws if open tag starts with a hyphen', () => {
     const callback = () => html`<-div></-div>`;
-    const expectedMessage = '[#120]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#120]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if open tag starts with a number', () => {
+  test('throws if open tag starts with a number', () => {
     const callback = () => html`<3h-></3h->`;
-    const expectedMessage = '[#120]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#120]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if open tag ends in a hyphen', () => {
+  test('throws if open tag ends in a hyphen', () => {
     const callback = () => html`<div-></div->`;
-    const expectedMessage = '[#120]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#120]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if you give a tag name with capital letters', () => {
+  test('throws if you give a tag name with capital letters', () => {
     const callback = () => html`<Div></Div>`;
-    const expectedMessage = '[#120]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#120]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if you give a custom element tag name with capital letters', () => {
+  test('throws if you give a custom element tag name with capital letters', () => {
     const callback = () => html`<my-Element></my-Element>`;
-    const expectedMessage = '[#120]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#120]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if an open tag has a trailing space before the ">" character', () => {
+  test('throws if an open tag has a trailing space before the ">" character', () => {
     const callback = () => html`<div foo ></div>`;
-    const expectedMessage = '[#122]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#122]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if an open tag has a trailing newline before the ">" character', () => {
+  test('throws if an open tag has a trailing newline before the ">" character', () => {
     const callback = () => html`
       <div
         foo
       >
       </div>
     `;
-    const expectedMessage = '[#122]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#122]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if an open tag has a slash before the ">" character', () => {
+  test('throws if an open tag has a slash before the ">" character', () => {
     const callback = () => html`<input foo/>`;
-    const expectedMessage = '[#104]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#104]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if an open tag has a space-slash before the ">" character', () => {
+  test('throws if an open tag has a space-slash before the ">" character', () => {
     const callback = () => html`<input foo />`;
-    const expectedMessage = '[#122]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#122]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for tabs after open tag start', () => {
+  test('throws for tabs after open tag start', () => {
     // There is a literal tab character here.
     const callback = () => html`<div	></div>`;
-    const expectedMessage = '[#121]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#121]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for tabs between declarations in an open tag', () => {
+  test('throws for tabs between declarations in an open tag', () => {
     // There is a literal tab character between the two boolean attributes here.
     const callback = () => html`<div foo	bar></div>`;
-    const expectedMessage = '[#121]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#121]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for multiple spaces between declarations in an open tag', () => {
+  test('throws for multiple spaces between declarations in an open tag', () => {
     // This sort of formatting is the only thing that _might_ make sense to
     //  allow in the future, but I think it’s fairly uncommon to use. Mostly,
     //  the multiple spaces are a typo when they exist.
@@ -904,740 +873,740 @@ describe('errors', () => {
       <div foo     bar></div>
       <div fooooo  bar></div>
     `;
-    const expectedMessage = '[#121]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#121]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for multiple newlines between declarations in an open tag', () => {
+  test('throws for multiple newlines between declarations in an open tag', () => {
     const callback = () => html`
       <div
         foo
         
         bar>
       </div>`;
-    const expectedMessage = '[#121]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#121]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a close tag has a space after the "<" characters', () => {
+  test('throws if a close tag has a space after the "<" characters', () => {
     const callback = () => html`<div>< /div>`;
-    const expectedMessage = '[#123]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#123]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a close tag has a space after the "</" characters', () => {
+  test('throws if a close tag has a space after the "</" characters', () => {
     const callback = () => html`<div></ div>`;
-    const expectedMessage = '[#123]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#123]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a close tag has a space before the ">" characters', () => {
+  test('throws if a close tag has a space before the ">" characters', () => {
     const callback = () => html`<div></div >`;
-    const expectedMessage = '[#123]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#123]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a close tag name ends with a hyphen', () => {
+  test('throws if a close tag name ends with a hyphen', () => {
     const callback = () => html`<div></div->`;
-    const expectedMessage = '[#123]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#123]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if there is other junk attached to the close tag', () => {
+  test('throws if there is other junk attached to the close tag', () => {
     const callback = () => html`<div></div class="nope">`;
-    const expectedMessage = '[#123]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#123]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if an unbound boolean attribute starts with a hyphen', () => {
+  test('throws if an unbound boolean attribute starts with a hyphen', () => {
     const callback = () => html`<div -what></div>`;
-    const expectedMessage = '[#124]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#124]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if an unbound boolean attribute starts with a number', () => {
+  test('throws if an unbound boolean attribute starts with a number', () => {
     const callback = () => html`<div 9what></div>`;
-    const expectedMessage = '[#124]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#124]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if an unbound boolean attribute has an uppercase letter', () => {
+  test('throws if an unbound boolean attribute has an uppercase letter', () => {
     const callback = () => html`<div wHat></div>`;
-    const expectedMessage = '[#124]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#124]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if an unbound boolean attribute ends with a hyphen', () => {
+  test('throws if an unbound boolean attribute ends with a hyphen', () => {
     const callback = () => html`<div what-></div>`;
-    const expectedMessage = '[#124]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#124]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if an unbound attribute starts with a hyphen', () => {
+  test('throws if an unbound attribute starts with a hyphen', () => {
     const callback = () => html`<div -what="no"></div>`;
-    const expectedMessage = '[#124]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#124]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if an unbound attribute starts with a number', () => {
+  test('throws if an unbound attribute starts with a number', () => {
     const callback = () => html`<div 5what="no"></div>`;
-    const expectedMessage = '[#124]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#124]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if an unbound attribute has an uppercase letter', () => {
+  test('throws if an unbound attribute has an uppercase letter', () => {
     const callback = () => html`<div wHat="no"></div>`;
-    const expectedMessage = '[#124]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#124]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if an unbound attribute ends with a hyphen', () => {
+  test('throws if an unbound attribute ends with a hyphen', () => {
     const callback = () => html`<div what-="no"></div>`;
-    const expectedMessage = '[#124]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#124]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound boolean attribute starts with a hyphen', () => {
+  test('throws if a bound boolean attribute starts with a hyphen', () => {
     const callback = () => html`<div ?-what="${VALUE}"></div>`;
-    const expectedMessage = '[#125]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#125]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound boolean attribute starts with a number', () => {
+  test('throws if a bound boolean attribute starts with a number', () => {
     const callback = () => html`<div ?3what="${VALUE}"></div>`;
-    const expectedMessage = '[#125]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#125]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound boolean attribute has an uppercase letter', () => {
+  test('throws if a bound boolean attribute has an uppercase letter', () => {
     const callback = () => html`<div ?wHat="${VALUE}"></div>`;
-    const expectedMessage = '[#125]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#125]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound boolean attribute ends with a hyphen', () => {
+  test('throws if a bound boolean attribute ends with a hyphen', () => {
     const callback = () => html`<div ?what-="${VALUE}"></div>`;
-    const expectedMessage = '[#125]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#125]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound boolean attribute has a malformed dangling quote', () => {
+  test('throws if a bound boolean attribute has a malformed dangling quote', () => {
     const callback = () => html`<div ?what="${VALUE} "></div>`;
-    const expectedMessage = '[#127]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#127]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound boolean attribute ends with a hyphen', () => {
+  test('throws if a bound boolean attribute ends with a hyphen', () => {
     const callback = () => html`<div ?what-="${VALUE}"></div>`;
-    const expectedMessage = '[#125]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#125]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound boolean attribute has a malformed dangling quote', () => {
+  test('throws if a bound boolean attribute has a malformed dangling quote', () => {
     const callback = () => html`<div ?what="${VALUE} "></div>`;
-    const expectedMessage = '[#127]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#127]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound boolean attribute is at the end of the template', () => {
+  test('throws if a bound boolean attribute is at the end of the template', () => {
     const callback = () => htmlol`<div ?bool="${VALUE}`;
-    const expectedMessage = '[#157]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#157]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound defined attribute starts with a hyphen', () => {
+  test('throws if a bound defined attribute starts with a hyphen', () => {
     const callback = () => html`<div ??-what="${VALUE}"></div>`;
-    const expectedMessage = '[#125]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#125]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound defined attribute starts with a number', () => {
+  test('throws if a bound defined attribute starts with a number', () => {
     const callback = () => html`<div ??3what="${VALUE}"></div>`;
-    const expectedMessage = '[#125]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#125]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound defined attribute has an uppercase letter', () => {
+  test('throws if a bound defined attribute has an uppercase letter', () => {
     const callback = () => html`<div ??wHat="${VALUE}"></div>`;
-    const expectedMessage = '[#125]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#125]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound defined attribute ends with a hyphen', () => {
+  test('throws if a bound defined attribute ends with a hyphen', () => {
     const callback = () => html`<div ??what-="${VALUE}"></div>`;
-    const expectedMessage = '[#125]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#125]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound defined attribute has a malformed dangling quote', () => {
+  test('throws if a bound defined attribute has a malformed dangling quote', () => {
     const callback = () => html`<div ??what="${VALUE} "></div>`;
-    const expectedMessage = '[#127]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#127]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound defined attribute is at the end of the template', () => {
+  test('throws if a bound defined attribute is at the end of the template', () => {
     const callback = () => htmlol`<div ??what="${VALUE}`;
-    const expectedMessage = '[#157]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#157]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound attribute starts with a hyphen', () => {
+  test('throws if a bound attribute starts with a hyphen', () => {
     const callback = () => html`<div -what="${VALUE}"></div>`;
-    const expectedMessage = '[#125]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#125]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound attribute starts with a number', () => {
+  test('throws if a bound attribute starts with a number', () => {
     const callback = () => html`<div 3what="${VALUE}"></div>`;
-    const expectedMessage = '[#125]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#125]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound attribute has an uppercase letter', () => {
+  test('throws if a bound attribute has an uppercase letter', () => {
     const callback = () => html`<div wHat="${VALUE}"></div>`;
-    const expectedMessage = '[#125]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#125]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound attribute ends with a hyphen', () => {
+  test('throws if a bound attribute ends with a hyphen', () => {
     const callback = () => html`<div what-="${VALUE}"></div>`;
-    const expectedMessage = '[#125]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#125]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound attribute has a malformed dangling quote', () => {
+  test('throws if a bound attribute has a malformed dangling quote', () => {
     const callback = () => html`<div what="${VALUE} "></div>`;
-    const expectedMessage = '[#127]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#127]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound attribute is at the end of the template', () => {
+  test('throws if a bound attribute is at the end of the template', () => {
     const callback = () => htmlol`<div what="${VALUE}`;
-    const expectedMessage = '[#157]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#157]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for misuse of a bound property prefix with a literal value', () => {
+  test('throws for misuse of a bound property prefix with a literal value', () => {
     const callback = () => html`<div .literal="property"></div>`;
-    const expectedMessage = '[#104]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#104]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound property starts with an underscore', () => {
+  test('throws if a bound property starts with an underscore', () => {
     const callback = () => html`<div ._what="${VALUE}"></div>`;
-    const expectedMessage = '[#126]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#126]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound property starts with a number', () => {
+  test('throws if a bound property starts with a number', () => {
     const callback = () => html`<div .3what="${VALUE}"></div>`;
-    const expectedMessage = '[#126]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#126]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound property starts with a capital letter', () => {
+  test('throws if a bound property starts with a capital letter', () => {
     const callback = () => html`<div .Yak="${VALUE}"></div>`;
-    const expectedMessage = '[#126]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#126]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound property ends with an underscore', () => {
+  test('throws if a bound property ends with an underscore', () => {
     const callback = () => html`<div .what_="${VALUE}"></div>`;
-    const expectedMessage = '[#126]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#126]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound property has a malformed dangling quote', () => {
+  test('throws if a bound property has a malformed dangling quote', () => {
     const callback = () => html`<div .what="${VALUE} "></div>`;
-    const expectedMessage = '[#127]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#127]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a bound property is at the end of the template', () => {
+  test('throws if a bound property is at the end of the template', () => {
     const callback = () => htmlol`<div .what="${VALUE}`;
-    const expectedMessage = '[#157]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#157]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if bound content is followed by a malformed close tag', () => {
+  test('throws if bound content is followed by a malformed close tag', () => {
     const callback = () => html`<div>${VALUE}</ div>`;
-    const expectedMessage = '[#123]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#123]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if you forget to close a tag', () => {
+  test('throws if you forget to close a tag', () => {
     const callback = () => html`<div>`;
-    const expectedMessage = '[#154]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#154]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if you mismatch a close a tag', () => {
+  test('throws if you mismatch a close a tag', () => {
     const callback = () => html`<div></span>`;
-    const expectedMessage = '[#154]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#154]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws if a close a tag is followed by malformed html', () => {
+  test('throws if a close a tag is followed by malformed html', () => {
     const callback = () => html`<div></div><-div>`;
-    const expectedMessage = '[#120]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#120]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for trying to write unicode in a js-y decimal format', () => {
+  test('throws for trying to write unicode in a js-y decimal format', () => {
     const callback1 = () => htmlol`<div>please no\x8230</div>`;
     const callback2 = () => htmlol`<div>please no\\\x8230</div>`;
-    const expectedMessage = '[#150]';
-    assertThrows(callback1, expectedMessage, { startsWith: true });
-    assertThrows(callback2, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#150]';
+    assert.throws(callback1, new RegExp('^' + RegExp.escape(expectedMessage)));
+    assert.throws(callback2, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for trying to write unicode in a js-y hexadecimal format', () => {
+  test('throws for trying to write unicode in a js-y hexadecimal format', () => {
     const callback1 = () => htmlol`<div>please no\u2026</div>`;
     const callback2 = () => htmlol`<div>please no\\\u2026</div>`;
-    const expectedMessage = '[#150]';
-    assertThrows(callback1, expectedMessage, { startsWith: true });
-    assertThrows(callback2, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#150]';
+    assert.throws(callback1, new RegExp('^' + RegExp.escape(expectedMessage)));
+    assert.throws(callback2, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for trying to write newlines in a js-y format', () => {
+  test('throws for trying to write newlines in a js-y format', () => {
     const callback1 = () => htmlol`<div>please no\n</div>`;
     const callback2 = () => htmlol`<div>please no\\\n</div>`;
-    const expectedMessage = '[#150]';
-    assertThrows(callback1, expectedMessage, { startsWith: true });
-    assertThrows(callback2, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#150]';
+    assert.throws(callback1, new RegExp('^' + RegExp.escape(expectedMessage)));
+    assert.throws(callback2, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for trying to write tabs in a js-y format', () => {
+  test('throws for trying to write tabs in a js-y format', () => {
     const callback1 = () => htmlol`<div>please no\t</div>`;
     const callback2 = () => htmlol`<div>please no\\\t</div>`;
-    const expectedMessage = '[#150]';
-    assertThrows(callback1, expectedMessage, { startsWith: true });
-    assertThrows(callback2, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#150]';
+    assert.throws(callback1, new RegExp('^' + RegExp.escape(expectedMessage)));
+    assert.throws(callback2, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for trying to write returns in a js-y format', () => {
+  test('throws for trying to write returns in a js-y format', () => {
     const callback1 = () => htmlol`<div>please no\r</div>`;
     const callback2 = () => htmlol`<div>please no\\\r</div>`;
-    const expectedMessage = '[#150]';
-    assertThrows(callback1, expectedMessage, { startsWith: true });
-    assertThrows(callback2, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#150]';
+    assert.throws(callback1, new RegExp('^' + RegExp.escape(expectedMessage)));
+    assert.throws(callback2, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for trying to write null characters in a js-y format', () => {
+  test('throws for trying to write null characters in a js-y format', () => {
     const callback1 = () => htmlol`<div>please no\0</div>`;
     const callback2 = () => htmlol`<div>please no\\\0</div>`;
-    const expectedMessage = '[#150]';
-    assertThrows(callback1, expectedMessage, { startsWith: true });
-    assertThrows(callback2, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#150]';
+    assert.throws(callback1, new RegExp('^' + RegExp.escape(expectedMessage)));
+    assert.throws(callback2, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for trying to write form feed characters in a js-y format', () => {
+  test('throws for trying to write form feed characters in a js-y format', () => {
     const callback1 = () => htmlol`<div>please no\f</div>`;
     const callback2 = () => htmlol`<div>please no\\\f</div>`;
-    const expectedMessage = '[#150]';
-    assertThrows(callback1, expectedMessage, { startsWith: true });
-    assertThrows(callback2, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#150]';
+    assert.throws(callback1, new RegExp('^' + RegExp.escape(expectedMessage)));
+    assert.throws(callback2, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for trying to write backspace characters in a js-y format', () => {
+  test('throws for trying to write backspace characters in a js-y format', () => {
     const callback1 = () => htmlol`<div>please no\b</div>`;
     const callback2 = () => htmlol`<div>please no\\\b</div>`;
-    const expectedMessage = '[#150]';
-    assertThrows(callback1, expectedMessage, { startsWith: true });
-    assertThrows(callback2, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#150]';
+    assert.throws(callback1, new RegExp('^' + RegExp.escape(expectedMessage)));
+    assert.throws(callback2, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for trying to write vertical tab characters in a js-y format', () => {
+  test('throws for trying to write vertical tab characters in a js-y format', () => {
     const callback1 = () => htmlol`<div>please no\v</div>`;
     const callback2 = () => htmlol`<div>please no\\\v</div>`;
-    const expectedMessage = '[#150]';
-    assertThrows(callback1, expectedMessage, { startsWith: true });
-    assertThrows(callback2, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#150]';
+    assert.throws(callback1, new RegExp('^' + RegExp.escape(expectedMessage)));
+    assert.throws(callback2, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for trying to write backslash', () => {
+  test('throws for trying to write backslash', () => {
     const callback1 = () => htmlol`<div>\\</div>`;
-    const expectedMessage = '[#150]';
-    assertThrows(callback1, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#150]';
+    assert.throws(callback1, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for trying to write literal backslash via an escape', () => {
+  test('throws for trying to write literal backslash via an escape', () => {
     const callback1 = () => htmlol`<div>\\</div>`;
-    const expectedMessage = '[#150]';
-    assertThrows(callback1, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#150]';
+    assert.throws(callback1, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for trying to write literal back tick via an escape', () => {
+  test('throws for trying to write literal back tick via an escape', () => {
     const callback1 = () => htmlol`<div>\`</div>`;
-    const expectedMessage = '[#150]';
-    assertThrows(callback1, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#150]';
+    assert.throws(callback1, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for trying to write literal dollar sign via an escape', () => {
+  test('throws for trying to write literal dollar sign via an escape', () => {
     const callback1 = () => htmlol`<div>\$</div>`;
-    const expectedMessage = '[#150]';
-    assertThrows(callback1, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#150]';
+    assert.throws(callback1, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for ambiguous ampersands', () => {
+  test('throws for ambiguous ampersands', () => {
     const callback = () => html`<div>please &a no</div>`;
-    const expectedMessage = '[#151]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#151]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for malformed comment because it starts with a ">" character', () => {
+  test('throws for malformed comment because it starts with a ">" character', () => {
     const callback = () => html`<!-->do not start with that character-->`;
-    const expectedMessage = '[#152]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#152]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for malformed comment because it starts with "->" characters', () => {
+  test('throws for malformed comment because it starts with "->" characters', () => {
     const callback = () => html`<!--->do not start with those characters-->`;
-    const expectedMessage = '[#152]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#152]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for malformed comment because it has "--" characters', () => {
+  test('throws for malformed comment because it has "--" characters', () => {
     const callback = () => html`<!--do not use "--" in a comment-->`;
-    const expectedMessage = '[#152]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#152]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for malformed comment because it ends with a "-" character', () => {
+  test('throws for malformed comment because it ends with a "-" character', () => {
     const callback = () => html`<!--do not end with this character--->`;
-    const expectedMessage = '[#152]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#152]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for initial CDATA sections', () => {
+  test('throws for initial CDATA sections', () => {
     const callback = () => html`<![CDATA[<]]> as &lt;!`;
-    const expectedMessage = '[#140]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#140]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for CDATA sections after unbound content', () => {
+  test('throws for CDATA sections after unbound content', () => {
     const callback = () => html`just encode <![CDATA[<]]> as &lt;!`;
-    const expectedMessage = '[#140]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#140]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for CDATA sections after bound content', () => {
+  test('throws for CDATA sections after bound content', () => {
     const callback = () => html`${VALUE}<![CDATA[<]]>${VALUE}`;
-    const expectedMessage = '[#140]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#140]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for CDATA sections after open tag', () => {
+  test('throws for CDATA sections after open tag', () => {
     const callback = () => html`<div><![CDATA[<]]></div>`;
-    const expectedMessage = '[#140]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#140]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for CDATA sections after close tag', () => {
+  test('throws for CDATA sections after close tag', () => {
     const callback = () => html`<div></div><![CDATA[<]]>`;
-    const expectedMessage = '[#140]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#140]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for forbidden <html> tag', () => {
+  test('throws for forbidden <html> tag', () => {
     const callback = () => html`<html></html>`;
-    const expectedMessage = '[#153]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#153]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for forbidden <head> tag', () => {
+  test('throws for forbidden <head> tag', () => {
     const callback = () => html`<head></head>`;
-    const expectedMessage = '[#153]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#153]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for forbidden <body> tag', () => {
+  test('throws for forbidden <body> tag', () => {
     const callback = () => html`<body></body>`;
-    const expectedMessage = '[#153]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#153]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for forbidden <base> tag', () => {
+  test('throws for forbidden <base> tag', () => {
     const callback = () => html`<base>`;
-    const expectedMessage = '[#153]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#153]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for forbidden <link> tag', () => {
+  test('throws for forbidden <link> tag', () => {
     const callback = () => html`<link>`;
-    const expectedMessage = '[#153]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#153]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for forbidden <meta> tag', () => {
+  test('throws for forbidden <meta> tag', () => {
     const callback = () => html`<meta>`;
-    const expectedMessage = '[#153]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#153]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for forbidden <title> tag', () => {
+  test('throws for forbidden <title> tag', () => {
     const callback = () => html`<title></title>`;
-    const expectedMessage = '[#153]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#153]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for forbidden <style> tag', () => {
+  test('throws for forbidden <style> tag', () => {
     const callback = () => html`<style></style>`;
-    const expectedMessage = '[#153]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#153]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for forbidden <script> tag', () => {
+  test('throws for forbidden <script> tag', () => {
     const callback = () => html`<script></script>`;
-    const expectedMessage = '[#153]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#153]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for forbidden <noscript> tag', () => {
+  test('throws for forbidden <noscript> tag', () => {
     const callback = () => html`<noscript></noscript>`;
-    const expectedMessage = '[#153]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#153]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for forbidden <canvas> tag', () => {
+  test('throws for forbidden <canvas> tag', () => {
     const callback = () => html`<canvas></canvas>`;
-    const expectedMessage = '[#153]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#153]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for forbidden <math> tag', () => {
+  test('throws for forbidden <math> tag', () => {
     const callback = () => html`<math></math>`;
-    const expectedMessage = '[#153]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#153]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for forbidden <svg> tag', () => {
+  test('throws for forbidden <svg> tag', () => {
     const callback = () => html`<svg></svg>`;
-    const expectedMessage = '[#153]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#153]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for declarative shadow roots', () => {
+  test('throws for declarative shadow roots', () => {
     const callback = () => html`<template shadowrootmode="open"></template>`;
-    const expectedMessage = '[#156]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#156]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 });
 
 // Sanity check to make sure we’re able to hit all our errors.
-describe('errors coverage', () => {
+suite('errors coverage', () => {
 
-  it('throws when initial markup cannot be parsed', () => {
+  test('throws when initial markup cannot be parsed', () => {
     const callback = () => htmlol`<`;
-    const expectedMessage = '[#100]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#100]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when markup after text cannot be parsed', () => {
+  test('throws when markup after text cannot be parsed', () => {
     const callback = () => htmlol`text<`;
-    const expectedMessage = '[#101]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#101]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when markup after comment cannot be parsed', () => {
+  test('throws when markup after comment cannot be parsed', () => {
     const callback = () => htmlol`<!--comment--><`;
-    const expectedMessage = '[#102]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#102]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when markup after content interpolation cannot be parsed', () => {
+  test('throws when markup after content interpolation cannot be parsed', () => {
     const callback = () => htmlol`${VALUE}<`;
-    const expectedMessage = '[#103]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#103]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when markup after start tag space cannot be parsed', () => {
+  test('throws when markup after start tag space cannot be parsed', () => {
     const callback = () => htmlol`<input !>`;
-    const expectedMessage = '[#104]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#104]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when markup after start tag cannot be parsed', () => {
+  test('throws when markup after start tag cannot be parsed', () => {
     const callback = () => htmlol`<div><`;
-    const expectedMessage = '[#105]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#105]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when markup after bound boolean cannot be parsed', () => {
+  test('throws when markup after bound boolean cannot be parsed', () => {
     const callback = () => htmlol`<div ?boolean="${VALUE}!`;
-    const expectedMessage = '[#106]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#106]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when markup after bound defined cannot be parsed', () => {
+  test('throws when markup after bound defined cannot be parsed', () => {
     const callback = () => htmlol`<div ??defined="${VALUE}!`;
-    const expectedMessage = '[#107]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#107]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when markup after bound attribute cannot be parsed', () => {
+  test('throws when markup after bound attribute cannot be parsed', () => {
     const callback = () => htmlol`<div attribute="${VALUE}!`;
-    const expectedMessage = '[#108]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#108]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when markup after bound property cannot be parsed', () => {
+  test('throws when markup after bound property cannot be parsed', () => {
     const callback = () => htmlol`<div .property="${VALUE}!`;
-    const expectedMessage = '[#109]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#109]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when markup after end tag cannot be parsed', () => {
+  test('throws when markup after end tag cannot be parsed', () => {
     const callback = () => htmlol`<div></div><`;
-    const expectedMessage = '[#110]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#110]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
   //////////////////////////////////////////////////////////////////////////////
 
-  it('throws when start tag is invalid', () => {
+  test('throws when start tag is invalid', () => {
     const callback = () => htmlol`<dIv>`;
-    const expectedMessage = '[#120]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#120]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when start tag space is invalid', () => {
+  test('throws when start tag space is invalid', () => {
     // There is a literal tab character here.
     const callback = () => htmlol`<div	>`;
-    const expectedMessage = '[#121]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#121]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when start tag close is invalid', () => {
+  test('throws when start tag close is invalid', () => {
     const callback = () => htmlol`<div foo />`;
-    const expectedMessage = '[#122]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#122]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when end tag is invalid', () => {
+  test('throws when end tag is invalid', () => {
     const callback = () => htmlol`<div></ div>`;
-    const expectedMessage = '[#123]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#123]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when attribute name is invalid', () => {
+  test('throws when attribute name is invalid', () => {
     const callback = () => htmlol`<div Boolean>`;
-    const expectedMessage = '[#124]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#124]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when bound attribute name is invalid', () => {
+  test('throws when bound attribute name is invalid', () => {
     const callback = () => htmlol`<div ?Boolean="${VALUE}">`;
-    const expectedMessage = '[#125]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#125]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when bound property name is invalid', () => {
+  test('throws when bound property name is invalid', () => {
     const callback = () => htmlol`<div .Property="${VALUE}">`;
-    const expectedMessage = '[#126]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#126]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when bound closing quote is invalid', () => {
+  test('throws when bound closing quote is invalid', () => {
     const callback = () => htmlol`<div attribute="${VALUE}'>`;
-    const expectedMessage = '[#127]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#127]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
   //////////////////////////////////////////////////////////////////////////////
 
-  it('throws when cdata exists', () => {
+  test('throws when cdata exists', () => {
     const callback = () => htmlol`<![CDATA[<]]>`;
-    const expectedMessage = '[#140]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#140]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
   //////////////////////////////////////////////////////////////////////////////
 
-  it('throws when escapes are used', () => {
+  test('throws when escapes are used', () => {
     const callback = () => htmlol`\n`;
-    const expectedMessage = '[#150]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#150]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when ambiguous ampersands are used', () => {
+  test('throws when ambiguous ampersands are used', () => {
     const callback = () => htmlol`&a`;
-    const expectedMessage = '[#151]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#151]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws when comments are invalid', () => {
+  test('throws when comments are invalid', () => {
     const callback = () => htmlol`<!-- -- -->`;
-    const expectedMessage = '[#152]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#152]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for unsupported (or unknown) native tags', () => {
+  test('throws for unsupported (or unknown) native tags', () => {
     const callback = () => htmlol`<style>`;
-    const expectedMessage = '[#153]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#153]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for wrong or missing end tag', () => {
+  test('throws for wrong or missing end tag', () => {
     const callback = () => htmlol`<div>`;
-    const expectedMessage = '[#154]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#154]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for textarea abuse', () => {
+  test('throws for textarea abuse', () => {
     const callback = () => htmlol`<textarea> -- ${VALUE} -- </textarea>`;
-    const expectedMessage = '[#155]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#155]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for declarative shadow root / shadowrootmode', () => {
+  test('throws for declarative shadow root / shadowrootmode', () => {
     const callback = () => htmlol`<template shadowrootmode>`;
-    const expectedMessage = '[#156]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#156]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 
-  it('throws for missing closing quote at end of template', () => {
+  test('throws for missing closing quote at end of template', () => {
     const callback = () => htmlol`<template foo="${VALUE}`;
-    const expectedMessage = '[#157]';
-    assertThrows(callback, expectedMessage, { startsWith: true });
+    const expectedMessage = 'Error: [#157]';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage)));
   });
 });
 
-describe('html error formatting', () => {
-  it('single line template', () => {
+suite('html error formatting', () => {
+  test('single line template', () => {
     const callback = () => html`<div id="target" not-ok=${VALUE}>Gotta double-quote those.</div>`;
-    const expectedMessage = '[#125] Invalid tag attribute interpolation (must use kebab-case names and double-quoted values).\nSee substring `not-ok=`.\nYour HTML was parsed through: `<div id="target" `.';
-    assertThrows(callback, expectedMessage);
+    const expectedMessage = 'Error: [#125] Invalid tag attribute interpolation (must use kebab-case names and double-quoted values).\nSee substring `not-ok=`.\nYour HTML was parsed through: `<div id="target" `.';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage) + '$'));
   });
 
-  it('template with two lines', () => {
+  test('template with two lines', () => {
     const callback = () => html`
       <div id="target" not-ok='${VALUE}'>Gotta double-quote those.</div>`;
-    const expectedMessage = '[#125] Invalid tag attribute interpolation (must use kebab-case names and double-quoted values).\nSee substring `not-ok=\'`.\nYour HTML was parsed through: `\n      <div id="target" `.';
-    assertThrows(callback, expectedMessage);
+    const expectedMessage = 'Error: [#125] Invalid tag attribute interpolation (must use kebab-case names and double-quoted values).\nSee substring `not-ok=\'`.\nYour HTML was parsed through: `\n      <div id="target" `.';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage) + '$'));
   });
 
-  it('template with three lines', () => {
+  test('template with three lines', () => {
     const callback = () => html`
       
       
       <div id="target" .notOk=${VALUE}>Gotta double-quote those.</div>`;
-    const expectedMessage = '[#126] Invalid tag property interpolation (must use kebab-case names and double-quoted values).\nSee substring `.notOk=`.\nYour HTML was parsed through: `\n      \n      \n      <div id="target" `.';
-    assertThrows(callback, expectedMessage);
+    const expectedMessage = 'Error: [#126] Invalid tag property interpolation (must use kebab-case names and double-quoted values).\nSee substring `.notOk=`.\nYour HTML was parsed through: `\n      \n      \n      <div id="target" `.';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage) + '$'));
   });
 });
 
-describe('validate', () => {
+suite('validate', () => {
   // For simple validation purposes — a noop “onToken” can be provided.
   const onToken = () => {};
   // eslint-disable-next-line no-shadow
   const html = strings => XParser.parse(strings, onToken);
 
-  it('basic templates work', () => {
+  test('basic templates work', () => {
     html`<div>hello world</div>`;
   });
 
-  it('complex templates work', () => {
+  test('complex templates work', () => {
     html`
       <div
         one="one"
@@ -1656,7 +1625,7 @@ describe('validate', () => {
 
   // The eslint-plugin-x-element package relies on error context to map
   //  parsing errors to source locations. These tests ensure the contract.
-  it('errors contain context for debugging', () => {
+  test('errors contain context for debugging', () => {
     let error;
     try {
       html`<diff>hello world</diff>`;
@@ -1673,7 +1642,7 @@ describe('validate', () => {
 
   // When an error occurs before character-level parsing begins (e.g., a raw
   //  string escape), start and end are null to signal no position is available.
-  it('initial error contains context for debugging', () => {
+  test('initial error contains context for debugging', () => {
     let error;
     try {
       html`this will fail immediately because of the following escape \u2026`;

--- a/test/test-property-deletion.js
+++ b/test/test-property-deletion.js
@@ -1,4 +1,4 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
 class TestElement extends XElement {
@@ -17,7 +17,7 @@ class TestElement extends XElement {
 }
 customElements.define('test-delete-element', TestElement);
 
-it('properties are non-configurable from construction', () => {
+test('properties are non-configurable from construction', () => {
   const el = document.createElement('test-delete-element');
   const descriptor = Object.getOwnPropertyDescriptor(el, 'foo');
   assert(descriptor !== undefined);
@@ -27,7 +27,7 @@ it('properties are non-configurable from construction', () => {
   assert(typeof descriptor.set === 'function');
 });
 
-it('prevents deletion of properties after construction', () => {
+test('prevents deletion of properties after construction', () => {
   const el = document.createElement('test-delete-element');
   assert('foo' in el);
   let passed = false;
@@ -42,7 +42,7 @@ it('prevents deletion of properties after construction', () => {
   assert('foo' in el);
 });
 
-it('returns false for Reflect.deleteProperty after construction', () => {
+test('returns false for Reflect.deleteProperty after construction', () => {
   const el = document.createElement('test-delete-element');
   assert('foo' in el);
   const result = Reflect.deleteProperty(el, 'foo');
@@ -50,7 +50,7 @@ it('returns false for Reflect.deleteProperty after construction', () => {
   assert('foo' in el);
 });
 
-it('properties remain non-configurable after initialization', () => {
+test('properties remain non-configurable after initialization', () => {
   const el = document.createElement('test-delete-element');
   document.body.append(el);
   const descriptor = Object.getOwnPropertyDescriptor(el, 'foo');

--- a/test/test-read-only-properties.js
+++ b/test/test-read-only-properties.js
@@ -1,4 +1,4 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
 class TestElement extends XElement {
@@ -23,14 +23,14 @@ class TestElement extends XElement {
 }
 customElements.define('test-element', TestElement);
 
-it('initialization', () => {
+test('initialization', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.shadowRoot.textContent === 'Dromedary', 'initialized correctly');
   assert(el.readOnlyProperty === 'Ferus', 'correct value after connection');
 });
 
-it('re-render in connectedCallback works', async () => {
+test('re-render in connectedCallback works', async () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.readOnlyProperty === 'Ferus', 'correct value after connection');
@@ -40,7 +40,7 @@ it('re-render in connectedCallback works', async () => {
   assert(el.shadowRoot.textContent === 'Ferus', 'correct value after re-render');
 });
 
-it('cannot be written to', () => {
+test('cannot be written to', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -55,7 +55,7 @@ it('cannot be written to', () => {
   assert(passed, message);
 });
 
-it('cannot be read from "internal"', () => {
+test('cannot be read from "internal"', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   let passed = false;
@@ -70,7 +70,7 @@ it('cannot be read from "internal"', () => {
   assert(passed, message);
 });
 
-it('cannot set to known properties', () => {
+test('cannot set to known properties', () => {
   class BadTestElement extends XElement {
     static get properties() {
       return {

--- a/test/test-reflected-properties.js
+++ b/test/test-reflected-properties.js
@@ -1,4 +1,4 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
 class TestElement extends XElement {
@@ -43,31 +43,31 @@ class TestElement extends XElement {
 customElements.define('test-element', TestElement);
 
 
-it('reflects initial value', () => {
+test('reflects initial value', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.getAttribute('camel-case-property') === 'reflectedCamel');
 });
 
-it('renders the template with the initial value', () => {
+test('renders the template with the initial value', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.shadowRoot.querySelector('span').textContent === 'reflectedCamel');
 });
 
-it('reflects initial value (Boolean, true)', () => {
+test('reflects initial value (Boolean, true)', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.hasAttribute('boolean-property-true'));
 });
 
-it('does not reflect initial value (Boolean, false)', () => {
+test('does not reflect initial value (Boolean, false)', () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.hasAttribute('boolean-property-false') === false);
 });
 
-it('reflects next value after a micro tick', async () => {
+test('reflects next value after a micro tick', async () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   el.camelCaseProperty = 'dromedary';
@@ -81,7 +81,7 @@ it('reflects next value after a micro tick', async () => {
   assert(el.shadowRoot.querySelector('span').textContent === 'dromedary');
 });
 
-it('has reflected override value after connected', async () => {
+test('has reflected override value after connected', async () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.getAttribute('override-property') === 'override_me');
@@ -91,7 +91,7 @@ it('has reflected override value after connected', async () => {
   assert(el.getAttribute('override-property') === 'overridden');
 });
 
-it('does not reflect next false value (Boolean)', async () => {
+test('does not reflect next false value (Boolean)', async () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.hasAttribute('boolean-property-true'));
@@ -111,7 +111,7 @@ it('does not reflect next false value (Boolean)', async () => {
 
 // Setting “reflect: false” explicitly should behave the same as omitting it.
 //  See https://github.com/Netflix/x-element/issues/353.
-it('does not error when reflect is explicitly set to false', async () => {
+test('does not error when reflect is explicitly set to false', async () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   el.explicitlyNotReflected = true;

--- a/test/test-render-root.js
+++ b/test/test-render-root.js
@@ -1,4 +1,4 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
 class TestElement1 extends XElement {
@@ -13,7 +13,7 @@ class TestElement1 extends XElement {
 }
 customElements.define('test-element-1', TestElement1);
 
-it('test render root was respected', () => {
+test('test render root was respected', () => {
   const el = document.createElement('test-element-1');
   document.body.append(el);
   assert(el.shadowRoot === null);
@@ -21,7 +21,7 @@ it('test render root was respected', () => {
   el.remove();
 });
 
-it('errors are thrown in for creating a bad render root', () => {
+test('errors are thrown in for creating a bad render root', () => {
   class BadElement extends XElement {
     static createRenderRoot() {}
   }

--- a/test/test-render.js
+++ b/test/test-render.js
@@ -1,4 +1,4 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
 class TestElement extends XElement {
@@ -28,7 +28,7 @@ class TestElement extends XElement {
 }
 customElements.define('test-element', TestElement);
 
-it('test super.render can be ignored', async () => {
+test('test super.render can be ignored', async () => {
   const el = document.createElement('test-element');
   document.body.append(el);
   assert(el.count === 1);
@@ -43,7 +43,7 @@ it('test super.render can be ignored', async () => {
   assert(el.shadowRoot.textContent === 'next');
 });
 
-it('test host is available', async () => {
+test('test host is available', async () => {
   const el = document.createElement('test-element');
   // Get around our render guard — we're not testing that here.
   el.count = 2;

--- a/test/test-scratch.js
+++ b/test/test-scratch.js
@@ -1,4 +1,4 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import XElement from '../x-element.js';
 
 class TestElement extends XElement {
@@ -108,7 +108,7 @@ class TestElement extends XElement {
 customElements.define('test-element', TestElement);
 
 
-it('scratch', async () => {
+test('scratch', async () => {
   const el = document.createElement('test-element');
   document.body.append(el);
 
@@ -198,7 +198,7 @@ it('scratch', async () => {
   document.body.append(el);
 });
 
-it('test dispatchError', () => {
+test('test dispatchError', () => {
   const el = document.createElement('test-element');
   const error = new Error('Foo');
   let passed = false;
@@ -220,7 +220,7 @@ it('test dispatchError', () => {
 
 // TODO: Firefox somehow returns an un-upgraded instance after adoption. This
 //  seems like a bug in the browser, but we should look into it.
-(navigator.userAgent.includes('Firefox') ? it.skip : it)('test adoptedCallback', () => {
+(navigator.userAgent.includes('Firefox') ? test.skip : test)('test adoptedCallback', () => {
   const el = document.createElement('test-element');
   el.prop1 = 'adopt me!';
   document.body.append(el);
@@ -235,7 +235,7 @@ it('test dispatchError', () => {
   assert(el.adopted);
 });
 
-it('authors can extend observed attributes', () => {
+test('authors can extend observed attributes', () => {
   const el = document.createElement('test-element');
   assert(!el.customObservedAttributeChange);
   el.setAttribute('custom-observed-attribute', '');

--- a/test/test-styles.js
+++ b/test/test-styles.js
@@ -1,4 +1,4 @@
-import { assert, it } from '@netflix/x-test/x-test.js';
+import { assert, test } from '@netflix/x-test/x-test.js';
 import styleSheet from './test-styles.css' with { type: 'css' };
 import XElement from '../x-element.js';
 
@@ -16,7 +16,7 @@ class TestElement1 extends XElement {
 }
 customElements.define('test-element-1', TestElement1);
 
-it('provided style sheets are adopted', () => {
+test('provided style sheets are adopted', () => {
   const el = document.createElement('test-element-1');
   document.body.append(el);
   const boundingClientRect = el.getBoundingClientRect();
@@ -25,7 +25,7 @@ it('provided style sheets are adopted', () => {
   el.remove();
 });
 
-it('should only get styles _once_ per constructor', () => {
+test('should only get styles _once_ per constructor', () => {
   for (let iii = 0; iii < 10; iii++) {
     // No matter how many times you do this, styles must only be accessed once.
     const el = document.createElement('test-element-1');
@@ -38,7 +38,7 @@ it('should only get styles _once_ per constructor', () => {
   }
 });
 
-it('errors are thrown when providing styles without a shadow root', () => {
+test('errors are thrown when providing styles without a shadow root', () => {
   class BadElement extends XElement {
     static get styles() { return [styleSheet]; }
     static createRenderRoot(host) { return host; }
@@ -56,7 +56,7 @@ it('errors are thrown when providing styles without a shadow root', () => {
   assert(passed, message);
 });
 
-it('errors are thrown when styles already exist on shadow root.', () => {
+test('errors are thrown when styles already exist on shadow root.', () => {
   class BadElement extends XElement {
     static get styles() { return [styleSheet]; }
     static createRenderRoot(host) {

--- a/test/test-template-engine.js
+++ b/test/test-template-engine.js
@@ -1,37 +1,21 @@
-import { assert, describe, it } from '@netflix/x-test/x-test.js';
+import { assert, suite, test } from '@netflix/x-test/x-test.js';
 import { render, html } from '../x-template.js';
 
-// Simple helper for asserting thrown messages.
-const assertThrows = (callback, expectedMessage, options) => {
-  let thrown = false;
-  try {
-    callback();
-  } catch (error) {
-    thrown = true;
-    if (options?.startsWith === true) {
-      assert(error.message.startsWith(expectedMessage), error.message);
-    } else {
-      assert(error.message === expectedMessage, error.message);
-    }
-  }
-  assert(thrown, 'no error was thrown');
-};
-
-describe('html rendering', () => {
-  it('renders empty template', () => {
+suite('html rendering', () => {
+  test('renders empty template', () => {
     const container = document.createElement('div');
     render(container, html``);
     assert(container.childNodes.length === 0);
   });
 
-  it('renders basic string', () => {
+  test('renders basic string', () => {
     const container = document.createElement('div');
     render(container, html`<div id="target">No interpolation.</div>`);
     assert(container.childNodes.length === 1);
     assert(container.querySelector('#target').textContent === 'No interpolation.');
   });
 
-  it('renders comments', () => {
+  test('renders comments', () => {
     const container = document.createElement('div');
     render(container, html`<!--This is HTML: "&ldquo;<div></div>&rdquo;"-->`);
     assert(container.childNodes.length === 1);
@@ -39,7 +23,7 @@ describe('html rendering', () => {
     assert(container.childNodes[0].textContent === 'This is HTML: "&ldquo;<div></div>&rdquo;"');
   });
 
-  it('renders void tags', () => {
+  test('renders void tags', () => {
     const container = document.createElement('div');
     render(container, html`<input><br><input>`);
     assert(container.childNodes.length === 3);
@@ -48,7 +32,7 @@ describe('html rendering', () => {
     assert(container.childNodes[2].localName === 'input');
   });
 
-  it('renders template elements', () => {
+  test('renders template elements', () => {
     // It’s important that the _content_ is populated here. Not the template.
     const container = document.createElement('div');
     render(container, html`<template><div><p></p></div></template>`);
@@ -58,7 +42,7 @@ describe('html rendering', () => {
     assert(container.querySelector('template').content.children[0].children[0].localName === 'p');
   });
 
-  it('renders pre elements with optional, initial newline', () => {
+  test('renders pre elements with optional, initial newline', () => {
     const expected = '        hi\n      ';
     const container = document.createElement('div');
     render(container, html`
@@ -69,45 +53,45 @@ describe('html rendering', () => {
     assert(container.querySelector('pre').textContent === expected); // first newline is removed
   });
 
-  it('renders named html entities in text content', () => {
+  test('renders named html entities in text content', () => {
     const container = document.createElement('div');
     render(container, html`<div>${'--'}&#123;&lt;&amp;&gt;&apos;&quot;&#x007D;${'--'}</div>`);
     assert(container.childNodes.length === 1);
     assert(container.childNodes[0].textContent === `--{<&>'"}--`);
   });
 
-  it('renders direct references in replaceable character data', () => {
+  test('renders direct references in replaceable character data', () => {
     const container = document.createElement('div');
     render(container, html`&amp;&lt;&gt;&quot;&apos;`);
     assert(container.textContent === `&<>"'`);
   });
 
-  it('renders references for commonly-used characters', () => {
+  test('renders references for commonly-used characters', () => {
     const container = document.createElement('div');
     render(container, html`&nbsp;&lsquo;&rsquo;&ldquo;&rdquo;&ndash;&mdash;&hellip;&bull;&middot;&dagger;`);
     assert(container.textContent === '\u00A0\u2018\u2019\u201C\u201D\u2013\u2014\u2026\u2022\u00B7\u2020');
   });
 
-  it('renders named references which require surrogate pairs', () => {
+  test('renders named references which require surrogate pairs', () => {
     const container = document.createElement('div');
     render(container,  html`<div>--&bopf;&bopf;--&bopf;--</div>`);
     assert(container.children[0].textContent === `--\uD835\uDD53\uD835\uDD53--\uD835\uDD53--`);
   });
 
-  it('leaves malformed references as-is', () => {
+  test('leaves malformed references as-is', () => {
     const container = document.createElement('div');
     render(container,  html`<div>--&:^);--</div>`);
     assert(container.children[0].textContent === `--&:^);--`);
   });
 
-  it('renders interpolated content without parsing', () => {
+  test('renders interpolated content without parsing', () => {
     const userContent = '<a href="https://evil.com">Click Me!</a>';
     const container = document.createElement('div');
     render(container, html`<div id="target">${userContent}</div>`);
     assert(container.querySelector('#target').textContent === userContent);
   });
 
-  it('renders null / undefined templates', () => {
+  test('renders null / undefined templates', () => {
     const container = document.createElement('div');
     render(container, html`<div></div>`);
     assert(!!container.childNodes.length);
@@ -119,7 +103,7 @@ describe('html rendering', () => {
     assert(!container.childNodes.length);
   });
 
-  it('renders solo interpolation', () => {
+  test('renders solo interpolation', () => {
     const container = document.createElement('div');
     render(container, html`${''}`);
     assert(container.childNodes.length === 3);
@@ -131,7 +115,7 @@ describe('html rendering', () => {
     assert(container.childNodes[2].data === '');
   });
 
-  it('renders adjacent interpolations', () => {
+  test('renders adjacent interpolations', () => {
     const container = document.createElement('div');
     render(container, html`${'hi'}${'there'}`);
     assert(container.childNodes.length === 6);
@@ -149,7 +133,7 @@ describe('html rendering', () => {
     assert(container.childNodes[5].data === '');
   });
 
-  it('renders interpolated content', () => {
+  test('renders interpolated content', () => {
     const getTemplate = ({ content }) => {
       return html`<div id="target">a b ${content}</div>`;
     };
@@ -163,7 +147,7 @@ describe('html rendering', () => {
   // Unlike a NodeList, a NamedNodeMap (i.e., “.attributes”) is not technically
   //  ordered in any way. This test just confirms that the template engine logic
   //  doesn’t get confused in any way post-parse.
-  it('renders elements with many attributes in a weird order', () => {
+  test('renders elements with many attributes in a weird order', () => {
     const getTemplate = ({
       property1,
       z99,
@@ -227,7 +211,7 @@ describe('html rendering', () => {
     assert(target.textContent.trim() === 'influencing');
   });
 
-  it('renders multiple, interpolated content', () => {
+  test('renders multiple, interpolated content', () => {
     const container = document.createElement('div');
     render(container, html`
       <div id="target">one: ${'ONE'} / two: ${'TWO'}</div>
@@ -235,7 +219,7 @@ describe('html rendering', () => {
     assert(container.querySelector('#target').textContent === 'one: ONE / two: TWO');
   });
 
-  it('renders nested content', () => {
+  test('renders nested content', () => {
     const getTemplate = ({ show, nestedContent }) => {
       return html`
         <div id="target">
@@ -254,7 +238,7 @@ describe('html rendering', () => {
     assert(container.querySelector('#conditional').textContent === 'k bye');
   });
 
-  it('renders attributes', () => {
+  test('renders attributes', () => {
     const getTemplate = ({ attr, content }) => {
       return html`<div id="target" attr="${attr}" f="b">Something<span>${content}</span></div>`;
     };
@@ -265,14 +249,14 @@ describe('html rendering', () => {
     assert(container.querySelector('#target').getAttribute('attr') === 'bar');
   });
 
-  it('renders references in attribute values', () => {
+  test('renders references in attribute values', () => {
     const container = document.createElement('div');
     render(container, html`<div foo="--&#123;&lt;&amp;&gt;&apos;&quot;&#x007D;--"></div>`);
     assert(container.childElementCount === 1);
     assert(container.children[0].getAttribute('foo') === `--{<&>'"}--`);
   });
 
-  it('renders boolean attributes', () => {
+  test('renders boolean attributes', () => {
     const getTemplate = ({ attr }) => {
       return html`<div id="target" ?attr="${attr}"></div>`;
     };
@@ -293,7 +277,7 @@ describe('html rendering', () => {
     assert(container.querySelector('#target').getAttribute('attr') === '');
   });
 
-  it('renders defined attributes', () => {
+  test('renders defined attributes', () => {
     const getTemplate = ({ attr }) => {
       return html`<div id="target" ??attr="${attr}"></div>`;
     };
@@ -316,7 +300,7 @@ describe('html rendering', () => {
     assert(container.querySelector('#target').getAttribute('attr') === 'true');
   });
 
-  it('renders properties', () => {
+  test('renders properties', () => {
     const getTemplate = ({ prop }) => {
       return html`
         <div
@@ -332,7 +316,7 @@ describe('html rendering', () => {
     assert(container.querySelector('#target').prop === 'bar');
   });
 
-  it('renders “on*” attributes as event handlers', () => {
+  test('renders “on*” attributes as event handlers', () => {
     const container = document.createElement('div');
     document.body.append(container);
     render(container, html`<div onclick="this.textContent = '&hellip;hi&hellip;';"></div>`);
@@ -346,7 +330,7 @@ describe('html rendering', () => {
     container.remove();
   });
 
-  it('renders “on*” properties as event handlers', () => {
+  test('renders “on*” properties as event handlers', () => {
     const container = document.createElement('div');
     document.body.append(container);
     render(container, html`<div .onclick="${function() { this.textContent = '…hi\u2026'; }}"></div>`);
@@ -358,7 +342,7 @@ describe('html rendering', () => {
     container.remove();
   });
 
-  it('maintains DOM nodes', () => {
+  test('maintains DOM nodes', () => {
     const getTemplate = ({ content }) => {
       return html`<div>${content}</div>`;
     };
@@ -372,7 +356,7 @@ describe('html rendering', () => {
     assert(container.querySelector('div').classList.contains('state'));
   });
 
-  it('renders lists', () => {
+  test('renders lists', () => {
     const getTemplate = ({ items }) => {
       return html`
         <div id="target">
@@ -388,7 +372,7 @@ describe('html rendering', () => {
     assert(container.querySelector('#target').children[2].textContent === 'baz');
   });
 
-  it('renders lists with multiple elements', () => {
+  test('renders lists with multiple elements', () => {
     const getTemplate = ({ items }) => {
       return html`
         <div id="target">
@@ -407,7 +391,7 @@ describe('html rendering', () => {
     assert(container.querySelector('#target').children[5].textContent === 'baz');
   });
 
-  it('renders lists with changing templates', () => {
+  test('renders lists with changing templates', () => {
     const getTemplate = ({ items }) => {
       return html`
         <div id="target">
@@ -427,7 +411,7 @@ describe('html rendering', () => {
     assert(container.querySelector('#target').children[2].classList.contains('true'));
   });
 
-  it('renders lists with changing length', () => {
+  test('renders lists with changing length', () => {
     const getTemplate = ({ items }) => {
       return html`
         <div id="target">
@@ -474,7 +458,7 @@ describe('html rendering', () => {
     assert(container.querySelector('#target').childElementCount === 2);
   });
 
-  it('renders lists of lists', () => {
+  test('renders lists of lists', () => {
     const getTemplate = ({ items }) => {
       return html`<div id="target">${items.map(item => {
         return html`${item.items.map(subItem => {
@@ -506,7 +490,7 @@ describe('html rendering', () => {
     assert(container.querySelector('#target').textContent === ':foo-one::foo-two::bar-one::bar-two::baz-one::baz-two:');
   });
 
-  it('renders multiple templates', () => {
+  test('renders multiple templates', () => {
     const getTemplate = ({ content }) => {
       if (content) {
         return html`<div id="content">${content}</div>`;
@@ -523,7 +507,7 @@ describe('html rendering', () => {
     assert(!!container.querySelector('#empty'));
   });
 
-  it('renders multiple templates (as content)', () => {
+  test('renders multiple templates (as content)', () => {
     const getTemplate = ({ content }) => {
       return html`
         <div id="target">
@@ -540,7 +524,7 @@ describe('html rendering', () => {
     assert(!!container.querySelector('#empty'));
   });
 
-  it('renders interpolated textarea (text binding)', () => {
+  test('renders interpolated textarea (text binding)', () => {
     const getTemplate = ({ defaultValue }) => {
       return html`<textarea id="target">${defaultValue}</textarea>`;
     };
@@ -551,7 +535,7 @@ describe('html rendering', () => {
     assert(container.querySelector('#target').textContent === 'default');
   });
 
-  it('renders instantiated elements as dumb text', () => {
+  test('renders instantiated elements as dumb text', () => {
     const getTemplate = ({ element }) => {
       return html`${element}`;
     };
@@ -561,7 +545,7 @@ describe('html rendering', () => {
     assert(container.textContent === '[object HTMLInputElement]');
   });
 
-  it('renders DocumentFragment nodes with simple append action', () => {
+  test('renders DocumentFragment nodes with simple append action', () => {
     const getTemplate = ({ fragment }) => {
       return html`${fragment}`;
     };
@@ -583,7 +567,7 @@ describe('html rendering', () => {
     assert(container.childNodes[1].nodeType === Node.COMMENT_NODE);
   });
 
-  it('renders the same template result multiple times for', () => {
+  test('renders the same template result multiple times for', () => {
     const rawResult = html`<div id="target"></div>`;
     const container1 = document.createElement('div');
     const container2 = document.createElement('div');
@@ -606,7 +590,7 @@ describe('html rendering', () => {
   //  element in the DOM. Previous to this test, constructors were invoked
   //  during template analysis when we computed a document fragment for later
   //  use as a clone base.
-  it('does not call custom element constructor during template analysis', () => {
+  test('does not call custom element constructor during template analysis', () => {
     let constructorCount = 0;
     class PhantomTestElement extends HTMLElement {
       constructor() {
@@ -623,7 +607,7 @@ describe('html rendering', () => {
     container.remove();
   });
 
-  it('causes single connect / disconnect for re-rendered elements', () => {
+  test('causes single connect / disconnect for re-rendered elements', () => {
     let connects = 0;
     let disconnects = 0;
     class TestConnectDisconnect extends HTMLElement {
@@ -663,7 +647,7 @@ describe('html rendering', () => {
     container.remove();
   });
 
-  it('native map renders basic template', () => {
+  test('native map renders basic template', () => {
     const getTemplate = ({ items }) => {
       return html`
         <div id="target">
@@ -722,7 +706,7 @@ describe('html rendering', () => {
     assert(container.querySelector('#target').children[2] !== baz);
   });
 
-  it('native map renders depth-first', async () => {
+  test('native map renders depth-first', async () => {
     const updates = [];
     class TestDepthFirstOuter extends HTMLElement {
       #item = null;
@@ -761,11 +745,11 @@ describe('html rendering', () => {
     assert(updates[1] === 'inner-foo', updates[1]);
     assert(updates[2] === 'outer-bar', updates[2]);
     assert(updates[3] === 'inner-bar', updates[3]);
-    assert(updates.length === 4, updates);
+    assert(updates.length === 4, JSON.stringify(updates, null, 2));
     container.remove();
   });
 
-  it('native map re-renders each time', () => {
+  test('native map re-renders each time', () => {
     const getTemplate = ({ items, lookup }) => {
       return html`
         <div>
@@ -794,7 +778,7 @@ describe('html rendering', () => {
     assert(container.querySelector('#c').textContent === 'fuzz');
   });
 
-  it('native map renders template changes', () => {
+  test('native map renders template changes', () => {
     const getTemplate = ({ items }) => {
       return html`
         <div id="target">
@@ -819,7 +803,7 @@ describe('html rendering', () => {
     assert(container.querySelector('#target').children[0] !== foo);
   });
 
-  it('native map with changing length', () => {
+  test('native map with changing length', () => {
     const getTemplate = ({ items }) => {
       return html`
         <div id="target">
@@ -867,7 +851,7 @@ describe('html rendering', () => {
   });
 
   // TODO: #254: Uncomment “moves” lines when we leverage “moveBefore”.
-  it('native map does not cause disconnectedCallback on prefix removal', () => {
+  test('native map does not cause disconnectedCallback on prefix removal', () => {
     let connects = 0;
     // let moves = 0;
     let disconnects = 0;
@@ -914,7 +898,7 @@ describe('html rendering', () => {
   });
 
   // TODO: #254: Uncomment “moves” lines when we leverage “moveBefore”.
-  it('native map does not cause disconnectedCallback on suffix removal', () => {
+  test('native map does not cause disconnectedCallback on suffix removal', () => {
     let connects = 0;
     // let moves = 0;
     let disconnects = 0;
@@ -961,7 +945,7 @@ describe('html rendering', () => {
   });
 
   // TODO: #254: See https://chromestatus.com/feature/5135990159835136.
-  it.todo('native map does not cause disconnectedCallback on list shuffle', () => {
+  test.todo('native map does not cause disconnectedCallback on list shuffle', () => {
     let connects = 0;
     let moves = 0;
     let disconnects = 0;
@@ -1008,7 +992,7 @@ describe('html rendering', () => {
   });
 });
 
-describe('changing content values', () => {
+suite('changing content values', () => {
   // The template engine needs to clear content between cursors if the updater
   //  changes — it‘d be far too complex to try and allow one updater try and
   //  take over from a different one.
@@ -1068,64 +1052,64 @@ describe('changing content values', () => {
     assert(container.querySelector('#target').textContent === '');
   };
 
-  it('can change from undefined content to null content', () => run(toUndefinedContent, toNullContent));
-  it('can change from undefined content to text content', () => run(toUndefinedContent, toTextContent));
-  it('can change from undefined content to fragment content', () => run(toUndefinedContent, toFragmentContent));
-  it('can change from undefined content to array content', () => run(toUndefinedContent, toArrayContent));
-  it('can change from undefined content to map content', () => run(toUndefinedContent, toMapContent));
+  test('can change from undefined content to null content', () => run(toUndefinedContent, toNullContent));
+  test('can change from undefined content to text content', () => run(toUndefinedContent, toTextContent));
+  test('can change from undefined content to fragment content', () => run(toUndefinedContent, toFragmentContent));
+  test('can change from undefined content to array content', () => run(toUndefinedContent, toArrayContent));
+  test('can change from undefined content to map content', () => run(toUndefinedContent, toMapContent));
 
-  it('can change from null content to undefined content', () => run(toNullContent, toUndefinedContent));
-  it('can change from null content to text content', () => run(toNullContent, toTextContent));
-  it('can change from null content to fragment content', () => run(toNullContent, toFragmentContent));
-  it('can change from null content to array content', () => run(toNullContent, toArrayContent));
-  it('can change from null content to map content', () => run(toNullContent, toMapContent));
+  test('can change from null content to undefined content', () => run(toNullContent, toUndefinedContent));
+  test('can change from null content to text content', () => run(toNullContent, toTextContent));
+  test('can change from null content to fragment content', () => run(toNullContent, toFragmentContent));
+  test('can change from null content to array content', () => run(toNullContent, toArrayContent));
+  test('can change from null content to map content', () => run(toNullContent, toMapContent));
 
-  it('can change from text content to undefined content', () => run(toTextContent, toUndefinedContent));
-  it('can change from text content to null content', () => run(toTextContent, toNullContent));
-  it('can change from text content to fragment content', () => run(toTextContent, toFragmentContent));
-  it('can change from text content to array content', () => run(toTextContent, toArrayContent));
-  it('can change from text content to map content', () => run(toTextContent, toMapContent));
+  test('can change from text content to undefined content', () => run(toTextContent, toUndefinedContent));
+  test('can change from text content to null content', () => run(toTextContent, toNullContent));
+  test('can change from text content to fragment content', () => run(toTextContent, toFragmentContent));
+  test('can change from text content to array content', () => run(toTextContent, toArrayContent));
+  test('can change from text content to map content', () => run(toTextContent, toMapContent));
 
-  it('can change from fragment content to undefined content', () => run(toFragmentContent, toUndefinedContent));
-  it('can change from fragment content to null content', () => run(toFragmentContent, toNullContent));
-  it('can change from fragment content to text content', () => run(toFragmentContent, toTextContent));
-  it('can change from fragment content to array content', () => run(toFragmentContent, toArrayContent));
-  it('can change from fragment content to map content', () => run(toFragmentContent, toMapContent));
+  test('can change from fragment content to undefined content', () => run(toFragmentContent, toUndefinedContent));
+  test('can change from fragment content to null content', () => run(toFragmentContent, toNullContent));
+  test('can change from fragment content to text content', () => run(toFragmentContent, toTextContent));
+  test('can change from fragment content to array content', () => run(toFragmentContent, toArrayContent));
+  test('can change from fragment content to map content', () => run(toFragmentContent, toMapContent));
 
-  it('can change from array content to undefined content', () => run(toArrayContent, toUndefinedContent));
-  it('can change from array content to null content', () => run(toArrayContent, toNullContent));
-  it('can change from array content to text content', () => run(toArrayContent, toTextContent));
-  it('can change from array content to fragment content', () => run(toArrayContent, toFragmentContent));
-  it('can change from array content to map content', () => run(toArrayContent, toMapContent));
+  test('can change from array content to undefined content', () => run(toArrayContent, toUndefinedContent));
+  test('can change from array content to null content', () => run(toArrayContent, toNullContent));
+  test('can change from array content to text content', () => run(toArrayContent, toTextContent));
+  test('can change from array content to fragment content', () => run(toArrayContent, toFragmentContent));
+  test('can change from array content to map content', () => run(toArrayContent, toMapContent));
 
-  it('can change from map content to undefined content', () => run(toMapContent, toUndefinedContent));
-  it('can change from map content to null content', () => run(toMapContent, toNullContent));
-  it('can change from map content to text content', () => run(toMapContent, toTextContent));
-  it('can change from map content to fragment content', () => run(toMapContent, toFragmentContent));
-  it('can change from map content to array content', () => run(toMapContent, toArrayContent));
+  test('can change from map content to undefined content', () => run(toMapContent, toUndefinedContent));
+  test('can change from map content to null content', () => run(toMapContent, toNullContent));
+  test('can change from map content to text content', () => run(toMapContent, toTextContent));
+  test('can change from map content to fragment content', () => run(toMapContent, toFragmentContent));
+  test('can change from map content to array content', () => run(toMapContent, toArrayContent));
 });
 
-describe('container issues', () => {
-  it('throws when given container is not a node', () => {
+suite('container issues', () => {
+  test('throws when given container is not a node', () => {
     const callback = () => render({}, html``);
-    const expectedMessage = 'Unexpected non-node render container "[object Object]".';
-    assertThrows(callback, expectedMessage);
+    const expectedMessage = 'Error: Unexpected non-node render container "[object Object]".';
+    assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage) + '$'));
   });
 });
 
-describe('value issues', () => {
-  describe('native array', () => {
-    it('throws for list with non-template value for array item', () => {
+suite('value issues', () => {
+  suite('native array', () => {
+    test('throws for list with non-template value for array item', () => {
       const callback = () => render(document.createElement('div'), html`
         <div>
           ${[null].map(item => item ? html`<div>${item}</div>` : null)}
         </div>
       `);
-      const expectedMessage = 'Unexpected non-template value found in array item at 0 "null".';
-      assertThrows(callback, expectedMessage);
+      const expectedMessage = 'Error: Unexpected non-template value found in array item at 0 "null".';
+      assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage) + '$'));
     });
 
-    it('throws for list with non-template value on re-render', () => {
+    test('throws for list with non-template value on re-render', () => {
       const getTemplate = ({ items }) => {
         return html`
           <div>
@@ -1136,35 +1120,35 @@ describe('value issues', () => {
       const container = document.createElement('div');
       render(container, getTemplate({ items: ['foo'] }));
       const callback = () => render(container, getTemplate({ items: [null] }));
-      const expectedMessage = 'Unexpected non-template value found in array item at 0 "null".';
-      assertThrows(callback, expectedMessage);
+      const expectedMessage = 'Error: Unexpected non-template value found in array item at 0 "null".';
+      assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage) + '$'));
     });
 
-    it('throws for list with empty map entry', () => {
+    test('throws for list with empty map entry', () => {
       const callback = () => render(document.createElement('div'), html`<div>${[[]]}</div>`);
-      const expectedMessage = 'Unexpected entry length found in map entry at 0 with length "0".';
-      assertThrows(callback, expectedMessage);
+      const expectedMessage = 'Error: Unexpected entry length found in map entry at 0 with length "0".';
+      assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage) + '$'));
     });
 
-    it('throws for list with non-string key in a map entry', () => {
+    test('throws for list with non-string key in a map entry', () => {
       const callback = () => render(document.createElement('div'), html`<div>${[[1, html``]]}</div>`);
-      const expectedMessage = 'Unexpected non-string key found in map entry at 0 "1".';
-      assertThrows(callback, expectedMessage);
+      const expectedMessage = 'Error: Unexpected non-string key found in map entry at 0 "1".';
+      assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage) + '$'));
     });
 
-    it('throws for list with duplicated key in a map entry', () => {
+    test('throws for list with duplicated key in a map entry', () => {
       const callback = () => render(
         document.createElement('div'),
         html`<div>${[['1', html``], ['2', html``], ['1', html``]]}</div>`,
       );
-      const expectedMessage = 'Unexpected duplicate key found in map entry at 2 "1".';
-      assertThrows(callback, expectedMessage);
+      const expectedMessage = 'Error: Unexpected duplicate key found in map entry at 2 "1".';
+      assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage) + '$'));
     });
 
-    it('throws for list with non-template values in a map entry', () => {
+    test('throws for list with non-template values in a map entry', () => {
       const callback = () => render(document.createElement('div'), html`<div>${[['1', null]]}</div>`);
-      const expectedMessage = 'Unexpected non-template value found in map entry at 0 "null".';
-      assertThrows(callback, expectedMessage);
+      const expectedMessage = 'Error: Unexpected non-template value found in map entry at 0 "null".';
+      assert.throws(callback, new RegExp('^' + RegExp.escape(expectedMessage) + '$'));
     });
   });
 });

--- a/x-test.config.js
+++ b/x-test.config.js
@@ -1,0 +1,11 @@
+export default {
+  url:      'http://127.0.0.1:8080/test/',
+  client:   'puppeteer',
+  browser:  'chromium',
+  coverage: true,
+  coverageGoals: {
+    './x-element.js':  { lines: 100 },
+    './x-parser.js':   { lines: 100 },
+    './x-template.js': { lines: 100 },
+  },
+};


### PR DESCRIPTION
Adopts the latest interface changes which align more-closely to Node’s `node --test`, `node:test`, and `node:assert` standards.

Some notes:

- Coverage moved to the CLI library, see `x-test.config.js`.
- Conventional `./coverage/lcov.info` files get generated when you test.
- Failures get re-iterated in output (for easy AI `tail`-ing).
- Output TAP stream is stylized in supported terminals / environments.
- Top-level interface is `load`, `suite`, `test`, and `assert` now.

<img width="1310" height="1274" alt="Screenshot 2026-04-24 at 2 43 25 PM" src="https://github.com/user-attachments/assets/d280fad7-0900-4e24-8577-16fa3394974a" />