### PR TITLE
Fix tests yielding false positives.

### DIFF
--- a/test/test-template-engine.js
+++ b/test/test-template-engine.js
@@ -342,20 +342,19 @@ describe('html rendering', () => {
     //  to-be-evaluated JS script. The default template engine doesn’t allow 
     //  any character escapes, so there is no way to pass “\u2026” as we can
     //  below in the interpolated property test.
-    assert(container.firstElementChild.textContent = '…hi…');
+    assert(container.firstElementChild.textContent === '…hi…');
     container.remove();
   });
 
   it('renders “on*” properties as event handlers', () => {
     const container = document.createElement('div');
     document.body.append(container);
-    render(container, html`<div .onclick="${'function() { this.textContent = \'…hi\u2026\'; }'}"></div>`);
+    render(container, html`<div .onclick="${function() { this.textContent = '…hi\u2026'; }}"></div>`);
     container.firstElementChild.click();
-    // Because attributes have _replaceable_ content, the “&hellip;” should be
-    //  immediately replaced and injected as the actual character “…” within the
-    //  to-be-evaluated JS script. Because the “\u2026” is interpolated, it’s
-    //  not validated at all (it’s not even seen by the parser).
-    assert(container.firstElementChild.textContent = '…hi…');
+    // Note that the “\u2026” has _nothing_ to do with our parsing logic. It
+    //  simply is interpreted as the literal “…” character as part of an actual
+    //  function reference which is bound to “onclick” as a property.
+    assert(container.firstElementChild.textContent === '…hi…');
     container.remove();
   });
 


### PR DESCRIPTION
A couple of tests were not really testing anything due to using `=` instead of `===` inside the `assert` call.

One test remained passing, the other needed an update, which is described below.

```js
// old test code
html`<div .onclick="${'function() { this.textContent = \'…hi\u2026\'; }'}"></div>`
```

```js
// new test code
html`<div .onclick="${function() { this.textContent = '…hi\u2026'; }}"></div>`
```

The old test code never quite made sense as according to the [specification](https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-attributes), a string would be coerced to `null` and then of course no event handling would occur (which happens as expected).

In other words…

```js
element.onclick = () => { console.log('hi'); }
element.onclick
// () => { console.log('hi'); }
element.click();
// hi

element.onclick = "() => { console.log('hi'); }"
element.onclick
// null
element.click();
// (nothing is logged)
```

Closes #371.