### PR TITLE
Fix reference decoding in attribute values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `useUnknownInCatchVariables`, and `strictFunctionTypes` (#357).
 - Bump devDependencies (eslint 10, typescript 6, eslint-plugin-jsdoc 62, etc.).
 
+### Fixed
+- Markup-shaped plaintext (e.g., `<code>`) is no longer lost from attribute
+  values and `textarea` content when it appears alongside a character reference
+  (e.g., `&amp;`). Previously, the presence of any reference caused text to be
+  re-parsed as markup (#373).
+
 ## [2.0.2] - 2026-03-10
 
 ### Fixed

--- a/test/test-template-engine.js
+++ b/test/test-template-engine.js
@@ -84,6 +84,12 @@ suite('html rendering', () => {
     assert(container.children[0].textContent === `--&:^);--`);
   });
 
+  test('renders non-interpolated <textarea> content with special characters and html entities', () => {
+    const container = document.createElement('div');
+    render(container, html`<textarea><em>this</em> is the &ldquo;default&rdquo; value</textarea>`);
+    assert(container.querySelector('textarea').value === '<em>this</em> is the “default” value');
+  });
+
   test('renders interpolated content without parsing', () => {
     const userContent = '<a href="https://evil.com">Click Me!</a>';
     const container = document.createElement('div');
@@ -254,6 +260,12 @@ suite('html rendering', () => {
     render(container, html`<div foo="--&#123;&lt;&amp;&gt;&apos;&quot;&#x007D;--"></div>`);
     assert(container.childElementCount === 1);
     assert(container.children[0].getAttribute('foo') === `--{<&>'"}--`);
+  });
+
+  test('renders non-interpolated attribute values with special characters and html entities', () => {
+    const container = document.createElement('div');
+    render(container, html`<div title="<code>tags</code> &amp; more"></div>`);
+    assert(container.children[0].getAttribute('title') === '<code>tags</code> & more');
   });
 
   test('renders boolean attributes', () => {

--- a/types/x-template.d.ts.map
+++ b/types/x-template.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"x-template.d.ts","sourceRoot":"","sources":["../x-template.js"],"names":[],"mappings":"AAm9BA,iCA/3BkC,WAAW,aAAa,OAAO,KAAK,IAAI,CA+3BC;AAC3E,6BAh4B4F,oBAAoB,aAAa,OAAO,EAAE,KAAK,OAAO,CAg4B3E"}
+{"version":3,"file":"x-template.d.ts","sourceRoot":"","sources":["../x-template.js"],"names":[],"mappings":"AA08BA,iCAv3BkC,WAAW,aAAa,OAAO,KAAK,IAAI,CAu3BC;AAC3E,6BAx3B4F,oBAAoB,aAAa,OAAO,EAAE,KAAK,OAAO,CAw3B3E"}

--- a/x-template.js
+++ b/x-template.js
@@ -43,7 +43,6 @@ class TemplateEngine {
    * @property {DocumentFragment | Element} element
    * @property {TagName} tagName
    * @property {number} childNodesIndex
-   * @property {boolean} encoded
    * @property {string} text
    * @property {string} name
    */
@@ -129,7 +128,7 @@ class TemplateEngine {
   }
 
   /**
-   * We only decode things we know to be encoded since it’s non-performant.
+   * Decode a character reference via “setHTMLUnsafe”.
    * @param {string} encoded
    * @returns {string}
    */
@@ -214,36 +213,29 @@ class TemplateEngine {
         break;
       case XParser.tokenTypes.textReference:
       case XParser.tokenTypes.attributeValueReference:
-        state.text += substring;
-        state.encoded = true;
+        state.text += TemplateEngine.#decode(substring);
         break;
-      case XParser.tokenTypes.textEnd: {
-        const decoded = state.encoded ? TemplateEngine.#decode(state.text) : state.text;
+      case XParser.tokenTypes.textEnd:
         if (
           state.tagName === 'pre' &&
           state.childNodesIndex === -1 &&
-          decoded.startsWith('\n')
+          state.text.startsWith('\n')
         ) {
           // First newline is stripped according to the <pre> tag specification.
           //  https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element
-          state.element.appendChild(TemplateEngine.#document.createTextNode(decoded.slice(1)));
+          state.element.appendChild(TemplateEngine.#document.createTextNode(state.text.slice(1)));
         } else {
-          state.element.appendChild(TemplateEngine.#document.createTextNode(decoded));
+          state.element.appendChild(TemplateEngine.#document.createTextNode(state.text));
         }
         state.childNodesIndex += 1;
-        state.encoded = false;
         state.text = '';
         break;
-      }
-      case XParser.tokenTypes.attributeValueEnd: {
-        const decoded = state.encoded ? TemplateEngine.#decode(state.text) : state.text;
+      case XParser.tokenTypes.attributeValueEnd:
         // @ts-expect-error — TS doesn’t get that this is an element.
-        state.element.setAttribute(state.name, decoded);
+        state.element.setAttribute(state.name, state.text);
         state.name = '';
-        state.encoded = false;
         state.text = '';
         break;
-      }
       case XParser.tokenTypes.boundTextValue:
         onText(state.path);
         break;
@@ -815,7 +807,6 @@ class TemplateEngine {
         element: fragment,
         tagName: null,
         childNodesIndex: -1,
-        encoded: false,
         text: '',
         name: '',
       });


### PR DESCRIPTION
Previously, we accumulated text that had encoded entities (e.g., like “&amp;”) until we hit the _end_ of the text — then decoded the whole string at once via `setHTMLUnsafe`. BUT, this wrongly was parsing values with _tags_ into HTML (when all we wanted was to decode entities).

The fix is to _only_ use `setHTMLUnsafe` to decode exactly one HTML entity at a time. Theoretically, this could cause performance issues for some edge / pathological cases.

Note: this also fixes text parsing / decoding for `<textarea>` content which suffered from the same bug.

Closes #373.